### PR TITLE
feat: Add compact network badge component for Stellar environment

### DIFF
--- a/docs/NetworkBadge.md
+++ b/docs/NetworkBadge.md
@@ -1,0 +1,88 @@
+# NetworkBadge Component
+
+A compact, reusable badge component for displaying the active Stellar network environment (testnet or mainnet).
+
+## Features
+
+- Compact design suitable for headers and transaction surfaces
+- Support for testnet and mainnet states
+- Optional status indicator dot
+- Dark mode support
+- Fully accessible with ARIA labels
+- Consistent styling with the rest of the application
+
+## Usage
+
+```tsx
+import { NetworkBadge } from '@/components/common/NetworkBadge';
+
+// Basic usage - testnet (default)
+<NetworkBadge />
+
+// Mainnet
+<NetworkBadge network="mainnet" />
+
+// Without indicator dot
+<NetworkBadge network="testnet" showIndicator={false} />
+
+// With custom className
+<NetworkBadge network="mainnet" className="ml-4" />
+```
+
+## Props
+
+| Prop            | Type                     | Default     | Description                              |
+| --------------- | ------------------------ | ----------- | ---------------------------------------- |
+| `network`       | `'testnet' \| 'mainnet'` | `'testnet'` | The network type to display              |
+| `showIndicator` | `boolean`                | `true`      | Whether to show the status indicator dot |
+| `className`     | `string`                 | `undefined` | Additional CSS classes to apply          |
+
+## Examples
+
+### In a Header
+
+```tsx
+import { NetworkBadge } from '@/components/common/NetworkBadge';
+
+function AppHeader() {
+	const currentNetwork = import.meta.env.VITE_STELLAR_NETWORK || 'testnet';
+
+	return (
+		<header className="flex items-center justify-between p-4">
+			<h1>My Stellar App</h1>
+			<NetworkBadge network={currentNetwork as 'testnet' | 'mainnet'} />
+		</header>
+	);
+}
+```
+
+### In a Transaction Surface
+
+```tsx
+import { NetworkBadge } from '@/components/common/NetworkBadge';
+
+function TransactionCard({ transaction }) {
+	return (
+		<div className="card">
+			<div className="flex items-center justify-between">
+				<h3>Transaction Details</h3>
+				<NetworkBadge network="mainnet" />
+			</div>
+			{/* Transaction details */}
+		</div>
+	);
+}
+```
+
+## Styling
+
+The component uses Tailwind CSS classes and supports both light and dark modes:
+
+- **Testnet**: Yellow color scheme (bg-yellow-100/dark:bg-yellow-900/30)
+- **Mainnet**: Green color scheme (bg-green-100/dark:bg-green-900/30)
+
+## Accessibility
+
+- Uses semantic HTML with `role="status"`
+- Includes `aria-label` for screen readers
+- Indicator dot marked as `aria-hidden` to avoid redundant announcements

--- a/src/components/common/NetworkBadge.tsx
+++ b/src/components/common/NetworkBadge.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const networkBadgeVariants = cva(
+	'inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors',
+	{
+		variants: {
+			network: {
+				testnet:
+					'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+				mainnet:
+					'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+			},
+		},
+		defaultVariants: {
+			network: 'testnet',
+		},
+	}
+);
+
+export interface NetworkBadgeProps
+	extends
+		React.HTMLAttributes<HTMLDivElement>,
+		VariantProps<typeof networkBadgeVariants> {
+	/**
+	 * The network type to display
+	 */
+	network?: 'testnet' | 'mainnet';
+	/**
+	 * Whether to show the status indicator dot
+	 */
+	showIndicator?: boolean;
+}
+
+const NetworkBadge = React.forwardRef<HTMLDivElement, NetworkBadgeProps>(
+	(
+		{ className, network = 'testnet', showIndicator = true, ...props },
+		ref
+	) => {
+		return (
+			<div
+				ref={ref}
+				className={cn(networkBadgeVariants({ network, className }))}
+				role="status"
+				aria-label={`Stellar ${network} network`}
+				{...props}
+			>
+				{showIndicator && (
+					<span
+						className={cn(
+							'size-1.5 rounded-full',
+							network === 'testnet'
+								? 'bg-yellow-600 dark:bg-yellow-400'
+								: 'bg-green-600 dark:bg-green-400'
+						)}
+						aria-hidden="true"
+					/>
+				)}
+				<span className="capitalize">{network}</span>
+			</div>
+		);
+	}
+);
+
+NetworkBadge.displayName = 'NetworkBadge';
+
+export { NetworkBadge, networkBadgeVariants };


### PR DESCRIPTION
## Summary
- Created a reusable NetworkBadge component for displaying Stellar testnet/mainnet environment
- Implemented compact design suitable for headers and transaction surfaces
- Added dark mode support with appropriate color schemes (yellow for testnet, green for mainnet)
- Included optional status indicator dot for enhanced visual clarity
- Provided comprehensive documentation with usage examples
- Ensured full accessibility with ARIA labels and semantic HTML

## Changes
- **src/components/common/NetworkBadge.tsx**: New component implementation using CVA for variants
- **docs/NetworkBadge.md**: Complete documentation with props, examples, and accessibility notes

## Testing
The component can be tested by importing and rendering in any page:
\`\`\`tsx
import { NetworkBadge } from '@/components/common/NetworkBadge';

<NetworkBadge network="testnet" />
<NetworkBadge network="mainnet" />
\`\`\`

Closes #14