### PR TITLE
feat: add wallet reconnect retry action in disconnect banner (Issue #…

### DIFF
--- a/src/components/common/WalletConnectCalloutBanner.tsx
+++ b/src/components/common/WalletConnectCalloutBanner.tsx
@@ -1,6 +1,8 @@
+import { useState } from 'react';
 import { Wallet } from 'lucide-react';
+import { useAccount, useConnect, useReconnect } from 'wagmi';
 import { cn } from '@/lib/utils';
-import ConnectWalletButton from '@/components/common/ConnectWalletButton';
+import showToast from '@/utils/toast.util';
 
 interface WalletConnectCalloutBannerProps {
 	title?: string;
@@ -13,6 +15,57 @@ const WalletConnectCalloutBanner: React.FC<WalletConnectCalloutBannerProps> = ({
 	description = 'Connect your wallet to continue with creator key purchases and on-chain actions.',
 	className,
 }) => {
+	const { isConnected } = useAccount();
+	const { reconnectAsync, connectors: reconnectConnectors } = useReconnect();
+	const { connectAsync, connectors: connectConnectors } = useConnect();
+	const [isReconnecting, setIsReconnecting] = useState(false);
+
+	const retryConnector = reconnectConnectors[0] ?? connectConnectors[0];
+
+	const handleReconnect = async () => {
+		if (isReconnecting) {
+			return;
+		}
+
+		if (isConnected) {
+			showToast.success('Wallet is already connected.');
+			return;
+		}
+
+		setIsReconnecting(true);
+		showToast.loading('Reconnecting wallet...');
+
+		try {
+			const reconnectResults = await reconnectAsync();
+			const didReconnect = reconnectResults.some(
+				result => result.accounts.length > 0
+			);
+
+			if (didReconnect) {
+				showToast.success('Wallet reconnected successfully.');
+				return;
+			}
+
+			if (!retryConnector) {
+				showToast.error(
+					'No wallet connector is available. Open your wallet extension and try again.'
+				);
+				return;
+			}
+
+			await connectAsync({ connector: retryConnector });
+			showToast.success('Wallet connected successfully.');
+		} catch (error) {
+			const message =
+				error instanceof Error && error.message
+					? error.message
+					: 'Please try again after unlocking your wallet.';
+			showToast.error(`Reconnect failed. ${message}`);
+		} finally {
+			setIsReconnecting(false);
+		}
+	};
+
 	return (
 		<div
 			className={cn(
@@ -32,7 +85,14 @@ const WalletConnectCalloutBanner: React.FC<WalletConnectCalloutBannerProps> = ({
 					<p className="mt-1 text-xs text-amber-100/75">{description}</p>
 				</div>
 				<div className="shrink-0">
-					<ConnectWalletButton />
+					<button
+						type="button"
+						onClick={handleReconnect}
+						disabled={isReconnecting}
+						className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+					>
+						{isReconnecting ? 'Reconnecting...' : 'Reconnect Wallet'}
+					</button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
This pull request updates the `WalletConnectCalloutBanner` component to improve the wallet connection and reconnection experience. The changes introduce a new reconnection flow with user feedback, replacing the previous wallet connect button with a custom reconnect button that provides clearer status updates and error handling.

**Wallet connection and reconnection improvements:**

* Added logic to handle wallet reconnection using `wagmi` hooks (`useAccount`, `useConnect`, `useReconnect`), including asynchronous reconnection attempts and fallback to connecting if reconnection fails. User feedback is provided via toast notifications for success, loading, and error states. [[1]](diffhunk://#diff-0e84b0f049441b44e8261c87c90e82cedc3af9e464ab1c5052c21775f19f80eaR1-R5) [[2]](diffhunk://#diff-0e84b0f049441b44e8261c87c90e82cedc3af9e464ab1c5052c21775f19f80eaR18-R68)
* Replaced the `ConnectWalletButton` with a custom "Reconnect Wallet" button that is disabled during reconnection and displays appropriate text based on the connection state.
* Improved error handling and user messaging to guide users in case of connection issues, such as prompting them to unlock their wallet or install a wallet extension if no connector is available.

Closes #158 