### PR TITLE
feat: add skeleton loading state to CreatorProfileStatRow (#206)

### DIFF
--- a/src/components/common/CreatorProfileStatRow.tsx
+++ b/src/components/common/CreatorProfileStatRow.tsx
@@ -1,40 +1,85 @@
 import { cn } from '@/lib/utils';
 import CreatorProfileStatItem from './CreatorProfileStatItem';
+import Skeleton from '@/components/ui/skeleton';
 import type { ReactNode } from 'react';
 
 interface CreatorProfileStatItemData {
-	label: string;
-	value: ReactNode;
+  label: string;
+  value: ReactNode;
 }
 
 interface CreatorProfileStatRowProps {
-	items: CreatorProfileStatItemData[];
-	className?: string;
-	itemClassName?: string;
+  items: CreatorProfileStatItemData[];
+  className?: string;
+  itemClassName?: string;
+  isLoading?: boolean;
+  skeletonCount?: number;
 }
 
+const CreatorProfileStatRowSkeleton: React.FC<{
+  count: number;
+  className?: string;
+  itemClassName?: string;
+}> = ({ count, className, itemClassName }) => {
+  return (
+    <div
+      className={cn(
+        'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4',
+        className
+      )}
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <div
+          key={i}
+          className={cn(
+            'relative overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] px-4 py-4 backdrop-blur-md',
+            itemClassName
+          )}
+        >
+          {/* label */}
+          <Skeleton className="h-2.5 w-16" />
+          {/* value */}
+          <Skeleton className="mt-2.5 h-5 w-24" />
+        </div>
+      ))}
+    </div>
+  );
+};
+
 const CreatorProfileStatRow: React.FC<CreatorProfileStatRowProps> = ({
-	items,
-	className,
-	itemClassName,
+  items,
+  className,
+  itemClassName,
+  isLoading = false,
+  skeletonCount = 4,
 }) => {
-	return (
-		<div
-			className={cn(
-				'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4',
-				className
-			)}
-		>
-			{items.map(item => (
-				<CreatorProfileStatItem
-					key={item.label}
-					label={item.label}
-					value={item.value}
-					className={itemClassName}
-				/>
-			))}
-		</div>
-	);
+  if (isLoading) {
+    return (
+      <CreatorProfileStatRowSkeleton
+        count={skeletonCount}
+        className={className}
+        itemClassName={itemClassName}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4',
+        className
+      )}
+    >
+      {items.map(item => (
+        <CreatorProfileStatItem
+          key={item.label}
+          label={item.label}
+          value={item.value}
+          className={itemClassName}
+        />
+      ))}
+    </div>
+  );
 };
 
 export default CreatorProfileStatRow;

--- a/src/components/common/__tests__/CreatorProfileStatRow.test.tsx
+++ b/src/components/common/__tests__/CreatorProfileStatRow.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import CreatorProfileStatRow from '../CreatorProfileStatRow';
+
+const mockItems = [
+  { label: 'Followers', value: '1.2k' },
+  { label: 'Keys Held', value: '42' },
+  { label: 'Revenue', value: '$300' },
+  { label: 'Rank', value: '#5' },
+];
+
+describe('CreatorProfileStatRow', () => {
+  it('renders all stat items when not loading', () => {
+    render(<CreatorProfileStatRow items={mockItems} />);
+    expect(screen.getByText('Followers')).toBeInTheDocument();
+    expect(screen.getByText('Keys Held')).toBeInTheDocument();
+  });
+
+  it('renders skeleton and hides stat content when isLoading=true', () => {
+    render(<CreatorProfileStatRow items={mockItems} isLoading />);
+    expect(screen.queryByText('Followers')).toBeNull();
+    expect(screen.queryByText('Keys Held')).toBeNull();
+  });
+
+  it('skeleton renders correct number of placeholder cards', () => {
+    const { container } = render(
+      <CreatorProfileStatRow items={mockItems} isLoading skeletonCount={4} />
+    );
+    // Each skeleton card has 2 Skeleton divs (label + value)
+    const skeletonDivs = container.querySelectorAll('.animate-pulse');
+    expect(skeletonDivs).toHaveLength(8);
+  });
+});

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from '@/lib/utils';
+
+interface SkeletonProps {
+  className?: string;
+}
+
+const Skeleton: React.FC<SkeletonProps> = ({ className }) => {
+  return (
+    <div
+      className={cn('animate-pulse rounded-md bg-white/[0.08]', className)}
+    />
+  );
+};
+
+export default Skeleton;


### PR DESCRIPTION
## Summary
Adds a dedicated skeleton loading state to `CreatorProfileStatRow` to prevent layout shift during data hydration.

## Changes
- `src/components/ui/skeleton.tsx` — new reusable Skeleton primitive (`animate-pulse` + `bg-white/[0.08]`)
- `src/components/common/CreatorProfileStatRow.tsx` — added `isLoading` and `skeletonCount` props; skeleton mirrors exact dimensions and classes of `CreatorProfileStatItem`
- `src/components/common/__tests__/CreatorProfileStatRow.test.tsx` — new tests covering loaded state, skeleton state, and placeholder card count

## Test results
- 3 new tests added — all pass
- 5 failures in `KeySupplyBadge.test.tsx` are **pre-existing** (confirmed on `main` baseline: 7 failed before this PR, now 5)

## Validation
```bash
pnpm lint  # clean
pnpm test  # 3 new tests pass
```

Closes #206