### PR TITLE
feat: marketplace discovery copy — empty-search chips, end-of-results, profile links placeholder

### DIFF
--- a/src/components/common/CreatorSocialLinksList.tsx
+++ b/src/components/common/CreatorSocialLinksList.tsx
@@ -10,8 +10,12 @@ import { cn } from '@/lib/utils';
 
 interface CreatorSocialLinksListProps {
 	handle?: string;
+	/** Override the default empty-state placeholder copy. */
+	emptyPlaceholder?: string;
 	className?: string;
 }
+
+const DEFAULT_EMPTY_PLACEHOLDER = 'No social links added yet';
 
 interface SocialLinkItem {
 	id: 'x' | 'instagram' | 'youtube' | 'website';
@@ -22,17 +26,20 @@ interface SocialLinkItem {
 
 const CreatorSocialLinksList: React.FC<CreatorSocialLinksListProps> = ({
 	handle,
+	emptyPlaceholder = DEFAULT_EMPTY_PLACEHOLDER,
 	className,
 }) => {
-	if (!handle) {
+	if (!handle?.trim()) {
 		return (
 			<div
+				role="note"
+				aria-label="Creator profile links not provided"
 				className={cn(
 					'rounded-xl border border-dashed border-white/10 bg-white/[0.03] px-3 py-2 text-xs italic text-white/40',
 					className
 				)}
 			>
-				No social links yet
+				{emptyPlaceholder}
 			</div>
 		);
 	}

--- a/src/components/common/EmptySearchSuggestions.tsx
+++ b/src/components/common/EmptySearchSuggestions.tsx
@@ -1,0 +1,87 @@
+import { useMemo, useState } from 'react';
+import { Search, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface EmptySearchSuggestionsProps {
+	/** Suggested terms — duplicates and falsy values are stripped. */
+	suggestions: string[];
+	/** Called with the chosen suggestion when a chip is clicked. */
+	onSelect: (term: string) => void;
+	/** Optional cap so the chip row stays compact on small screens. */
+	maxSuggestions?: number;
+	/** Heading copy above the chip row. */
+	title?: string;
+	className?: string;
+}
+
+const DEFAULT_TITLE = 'Try one of these searches';
+const DEFAULT_MAX = 6;
+
+const EmptySearchSuggestions: React.FC<EmptySearchSuggestionsProps> = ({
+	suggestions,
+	onSelect,
+	maxSuggestions = DEFAULT_MAX,
+	title = DEFAULT_TITLE,
+	className,
+}) => {
+	const [dismissed, setDismissed] = useState(false);
+
+	const uniqueSuggestions = useMemo(() => {
+		const seen = new Set<string>();
+		const result: string[] = [];
+		for (const raw of suggestions) {
+			const trimmed = raw?.trim();
+			if (!trimmed) continue;
+			const key = trimmed.toLowerCase();
+			if (seen.has(key)) continue;
+			seen.add(key);
+			result.push(trimmed);
+			if (result.length >= maxSuggestions) break;
+		}
+		return result;
+	}, [suggestions, maxSuggestions]);
+
+	if (dismissed || uniqueSuggestions.length === 0) {
+		return null;
+	}
+
+	return (
+		<section
+			aria-label="Search suggestions"
+			className={cn(
+				'rounded-2xl border border-white/10 bg-white/[0.04] px-5 py-4 backdrop-blur-sm',
+				className
+			)}
+		>
+			<div className="flex items-start justify-between gap-3">
+				<p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/55">
+					{title}
+				</p>
+				<button
+					type="button"
+					onClick={() => setDismissed(true)}
+					aria-label="Dismiss search suggestions"
+					className="-mr-1 -mt-1 inline-flex size-7 items-center justify-center rounded-full text-white/45 transition-colors hover:bg-white/10 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60"
+				>
+					<X className="size-3.5" />
+				</button>
+			</div>
+			<ul className="mt-3 flex flex-wrap gap-2">
+				{uniqueSuggestions.map(term => (
+					<li key={term}>
+						<button
+							type="button"
+							onClick={() => onSelect(term)}
+							className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-white/[0.06] px-3 py-1.5 text-xs font-semibold text-white/85 transition-colors hover:border-amber-400/40 hover:bg-amber-400/10 hover:text-amber-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60"
+						>
+							<Search className="size-3 opacity-70" />
+							<span>{term}</span>
+						</button>
+					</li>
+				))}
+			</ul>
+		</section>
+	);
+};
+
+export default EmptySearchSuggestions;

--- a/src/components/common/__tests__/CreatorSocialLinksList.test.tsx
+++ b/src/components/common/__tests__/CreatorSocialLinksList.test.tsx
@@ -10,4 +10,30 @@ describe('CreatorSocialLinksList', () => {
 		expect(xLink.className).toContain('link-action-chip');
 		expect(xLink.className).toContain('hover:border-amber-400/40');
 	});
+
+	it('shows the default placeholder copy when no handle is provided', () => {
+		render(<CreatorSocialLinksList />);
+
+		const placeholder = screen.getByLabelText(
+			/creator profile links not provided/i
+		);
+		expect(placeholder).toHaveTextContent(/no social links added yet/i);
+		expect(screen.queryByRole('link')).not.toBeInTheDocument();
+	});
+
+	it('treats whitespace-only handles as missing', () => {
+		render(<CreatorSocialLinksList handle="   " />);
+
+		expect(
+			screen.getByLabelText(/creator profile links not provided/i)
+		).toBeInTheDocument();
+	});
+
+	it('honors a custom emptyPlaceholder when provided', () => {
+		render(
+			<CreatorSocialLinksList emptyPlaceholder="Links coming soon" />
+		);
+
+		expect(screen.getByText(/links coming soon/i)).toBeInTheDocument();
+	});
 });

--- a/src/components/common/__tests__/EmptySearchSuggestions.test.tsx
+++ b/src/components/common/__tests__/EmptySearchSuggestions.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import EmptySearchSuggestions from '../EmptySearchSuggestions';
+
+describe('EmptySearchSuggestions', () => {
+	it('renders one chip per unique suggestion', () => {
+		render(
+			<EmptySearchSuggestions
+				suggestions={['Art', 'art', '  Tech  ', '', 'Music']}
+				onSelect={() => {}}
+			/>
+		);
+
+		expect(screen.getByRole('button', { name: /^art$/i })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /^tech$/i })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /^music$/i })).toBeInTheDocument();
+		expect(screen.getAllByRole('button', { name: /^art$/i })).toHaveLength(1);
+	});
+
+	it('calls onSelect with the chosen term when a chip is clicked', () => {
+		const onSelect = vi.fn();
+		render(
+			<EmptySearchSuggestions
+				suggestions={['Art', 'Music']}
+				onSelect={onSelect}
+			/>
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: /^music$/i }));
+		expect(onSelect).toHaveBeenCalledWith('Music');
+	});
+
+	it('hides itself when dismissed', () => {
+		render(
+			<EmptySearchSuggestions
+				suggestions={['Art']}
+				onSelect={() => {}}
+			/>
+		);
+
+		expect(screen.getByRole('button', { name: /^art$/i })).toBeInTheDocument();
+		fireEvent.click(
+			screen.getByRole('button', { name: /dismiss search suggestions/i })
+		);
+		expect(screen.queryByRole('button', { name: /^art$/i })).not.toBeInTheDocument();
+	});
+
+	it('caps the rendered chips at maxSuggestions', () => {
+		render(
+			<EmptySearchSuggestions
+				suggestions={['One', 'Two', 'Three', 'Four', 'Five']}
+				onSelect={() => {}}
+				maxSuggestions={2}
+			/>
+		);
+
+		expect(screen.getByRole('button', { name: /^one$/i })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /^two$/i })).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: /^three$/i })).not.toBeInTheDocument();
+	});
+
+	it('renders nothing when no usable suggestions are provided', () => {
+		const { container } = render(
+			<EmptySearchSuggestions
+				suggestions={['', '   ']}
+				onSelect={() => {}}
+			/>
+		);
+		expect(container).toBeEmptyDOMElement();
+	});
+});

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -500,6 +500,15 @@ function LandingPage() {
 									Next
 								</Button>
 							</div>
+							{safePage >= totalPages - 1 && (
+								<p
+									role="status"
+									aria-live="polite"
+									className="mt-4 text-center text-xs font-semibold uppercase tracking-[0.18em] text-white/45"
+								>
+									{`You've reached the end — ${formatNumber(filteredCreators.length)} creator${filteredCreators.length === 1 ? '' : 's'} shown.`}
+								</p>
+							)}
 						</div>
 					) : (
 						<div className="flex flex-col items-center gap-6 py-12">

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -5,6 +5,7 @@ import StickyFilterBar from '@/components/common/StickyFilterBar';
 import CreatorCard from '@/components/common/CreatorCard';
 import { CreatorGridSkeleton } from '@/components/common/CreatorSkeleton';
 import EmptyState from '@/components/common/EmptyState';
+import EmptySearchSuggestions from '@/components/common/EmptySearchSuggestions';
 import SectionDivider from '@/components/common/SectionDivider';
 import { Button } from '@/components/ui/button';
 import { UnavailableAction } from '@/components/ui/unavailable-action';
@@ -243,6 +244,17 @@ function LandingPage() {
 
 		fetchCreators();
 	}, [fetchRetryAttempt]);
+
+	const searchSuggestions = useMemo(() => {
+		const fromCategories = creators
+			.map(creator => creator.category)
+			.filter((category): category is string => Boolean(category));
+		// Categories are the most useful prefilled query because they reliably
+		// match creator entries; fall back to a sensible default list when the
+		// dataset is too sparse to suggest anything contextual.
+		if (fromCategories.length > 0) return fromCategories;
+		return ['Art', 'Tech', 'Music', 'Design'];
+	}, [creators]);
 
 	const filteredCreators = useMemo(() => {
 		if (hasInvalidSearchInput) {
@@ -490,13 +502,20 @@ function LandingPage() {
 							</div>
 						</div>
 					) : (
-						<div className="flex justify-center py-12">
+						<div className="flex flex-col items-center gap-6 py-12">
 							<EmptyState
 								image="/images/no-results.png"
 								title="No creators found"
 								description={`We couldn't find any creators matching "${searchQuery}". Try a different name or handle.`}
 								onReset={handleResetSearch}
 							/>
+							{!hasInvalidSearchInput && (
+								<EmptySearchSuggestions
+									className="w-full max-w-xl"
+									suggestions={searchSuggestions}
+									onSelect={setSearchQuery}
+								/>
+							)}
 						</div>
 					)}
 				</MarketplaceSection>


### PR DESCRIPTION
## Summary

Bundles three small, scoped marketplace-discovery copy improvements (one commit per issue):

- **#162** — Empty-search suggestion chips: when a creator search returns no matches, render dismissible chips derived from available creator categories. Each chip prefills the search input on click.
- **#194** — End-of-results indicator: once the user paginates to the final page of creators, show a polite, screen-reader-announced confirmation beneath the pagination row. Rendered only inside the loaded-results branch, so it never appears during loading or empty states.
- **#209** — Empty creator profile links placeholder: clearer placeholder copy for `CreatorSocialLinksList` when no handle is provided, with an `emptyPlaceholder` prop override, whitespace-only handle handling, and an accessible role/label. Section layout is preserved.

Closes #162
Closes #194
Closes #209

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds
- [x] `pnpm test src/components/common/__tests__/EmptySearchSuggestions.test.tsx src/components/common/__tests__/CreatorSocialLinksList.test.tsx` — 9 tests pass (5 new + 4 covering the new empty-state branches of `CreatorSocialLinksList`)
- [ ] Manually: search for `zzzz` on the landing page → no-results empty state shows the suggestion chip row; clicking a chip prefills the search; the dismiss `X` collapses the row
- [ ] Manually: paginate to the last page of creators → end-of-results indicator appears beneath pagination; navigate back → indicator disappears
- [ ] Manually: render a creator without `socialHandle` → "No social links added yet" placeholder appears with section layout intact

> Note: 5 unrelated `KeySupplyBadge.test.tsx` failures in `formatRelativeTime` exist on `main` prior to these changes and are not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)