### PR TITLE
feat: add wallet connection status pill events (#136)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
 import { Toaster } from 'react-hot-toast';
 import { createBrowserRouter, RouterProvider } from 'react-router';
 import LandingPage from './pages/LandingPage';
+import { WalletProvider } from './contexts/WalletProvider';
+import { WalletButton } from './components/wallet/WalletButton';
+import { WalletStatusPill } from './components/wallet/WalletStatusPill';
 
 const router = createBrowserRouter([
 	{
@@ -11,7 +14,10 @@ const router = createBrowserRouter([
 
 function App() {
 	return (
+		
 		<>
+		<WalletProvider>
+
 			<Toaster
 				toastOptions={{
 					ariaProps: {
@@ -20,7 +26,10 @@ function App() {
 					},
 				}}
 			/>
+			<WalletStatusPill />
+        <WalletButton />
 			<RouterProvider router={router} />
+			 </WalletProvider>
 		</>
 	);
 }

--- a/src/components/wallet/WalletButton.tsx
+++ b/src/components/wallet/WalletButton.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { useWallet } from '../../hooks/useWallet';
+import { WalletStatusPill } from './WalletStatusPill';
+import { cn } from '../../lib/utils';
+
+interface WalletButtonProps {
+  className?: string;
+  showStatusPill?: boolean;
+}
+
+export const WalletButton: React.FC<WalletButtonProps> = ({ 
+  className,
+  showStatusPill = true 
+}) => {
+  const { status, address, connect, disconnect } = useWallet();
+
+  const isConnected = status === 'connected';
+  const isLoading = status === 'connecting' || status === 'reconnecting' || status === 'disconnecting';
+
+  const handleClick = () => {
+    if (isConnected) {
+      disconnect();
+    } else {
+      connect();
+    }
+  };
+
+  const formatAddress = (addr: string | null) => {
+    if (!addr) return '';
+    return `${addr.slice(0, 4)}...${addr.slice(-4)}`;
+  };
+
+  return (
+    <div className={cn('flex items-center gap-3', className)}>
+      {showStatusPill && <WalletStatusPill />}
+      
+      <button
+        onClick={handleClick}
+        disabled={isLoading}
+        className={cn(
+          'px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200',
+          'focus:outline-none focus:ring-2 focus:ring-offset-2',
+          isConnected
+            ? 'bg-slate-800 text-white hover:bg-slate-700 focus:ring-slate-500'
+            : 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500',
+          isLoading && 'opacity-70 cursor-not-allowed',
+          'disabled:opacity-50'
+        )}
+        aria-busy={isLoading}
+      >
+        {isLoading ? (
+          <span className="flex items-center gap-2">
+            <svg className="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+            </svg>
+            {status === 'connecting' && 'Connecting...'}
+            {status === 'reconnecting' && 'Reconnecting...'}
+            {status === 'disconnecting' && 'Disconnecting...'}
+          </span>
+        ) : isConnected ? (
+          <span className="flex items-center gap-2">
+            <span className="w-2 h-2 bg-emerald-400 rounded-full" />
+            {formatAddress(address)}
+          </span>
+        ) : (
+          'Connect Wallet'
+        )}
+      </button>
+    </div>
+  );
+};
+
+export default WalletButton;

--- a/src/components/wallet/WalletStatusPill.test.tsx
+++ b/src/components/wallet/WalletStatusPill.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { WalletStatusPill } from './WalletStatusPill';
+import { useWallet } from '../../hooks/useWallet';
+
+vi.mock('../../hooks/useWallet', () => ({
+  useWallet: vi.fn(),
+}));
+
+describe('WalletStatusPill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders disconnected status', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'disconnected' } as any);
+    render(<WalletStatusPill />);
+    expect(screen.getByText('Disconnected')).toBeInTheDocument();
+  });
+
+  it('renders connecting status', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'connecting' } as any);
+    render(<WalletStatusPill />);
+    expect(screen.getByText('Connecting...')).toBeInTheDocument();
+  });
+
+  it('renders connected status', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'connected' } as any);
+    render(<WalletStatusPill />);
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+  });
+
+  it('renders reconnecting status', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'reconnecting' } as any);
+    render(<WalletStatusPill />);
+    expect(screen.getByText('Reconnecting...')).toBeInTheDocument();
+  });
+
+  it('renders disconnecting status', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'disconnecting' } as any);
+    render(<WalletStatusPill />);
+    expect(screen.getByText('Disconnecting...')).toBeInTheDocument();
+  });
+
+  it('renders error status', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'error' } as any);
+    render(<WalletStatusPill />);
+    expect(screen.getByText('Connection Error')).toBeInTheDocument();
+  });
+});

--- a/src/components/wallet/WalletStatusPill.tsx
+++ b/src/components/wallet/WalletStatusPill.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useWallet } from '../../hooks/useWallet';
+import { cn } from '../../lib/utils';
+
+export type WalletStatus = 'disconnected' | 'connecting' | 'connected' | 'reconnecting' | 'disconnecting' | 'error';
+
+interface WalletStatusPillProps {
+  className?: string;
+}
+
+const statusConfig: Record<WalletStatus, { label: string; dotColor: string; bgColor: string; textColor: string }> = {
+  disconnected: {
+    label: 'Disconnected',
+    dotColor: 'bg-gray-400',
+    bgColor: 'bg-gray-100',
+    textColor: 'text-gray-600',
+  },
+  connecting: {
+    label: 'Connecting...',
+    dotColor: 'bg-yellow-400',
+    bgColor: 'bg-yellow-50',
+    textColor: 'text-yellow-700',
+  },
+  connected: {
+    label: 'Connected',
+    dotColor: 'bg-emerald-500',
+    bgColor: 'bg-emerald-50',
+    textColor: 'text-emerald-700',
+  },
+  reconnecting: {
+    label: 'Reconnecting...',
+    dotColor: 'bg-amber-400',
+    bgColor: 'bg-amber-50',
+    textColor: 'text-amber-700',
+  },
+  disconnecting: {
+    label: 'Disconnecting...',
+    dotColor: 'bg-orange-400',
+    bgColor: 'bg-orange-50',
+    textColor: 'text-orange-700',
+  },
+  error: {
+    label: 'Connection Error',
+    dotColor: 'bg-red-500',
+    bgColor: 'bg-red-50',
+    textColor: 'text-red-700',
+  },
+};
+
+export const WalletStatusPill: React.FC<WalletStatusPillProps> = ({ className }) => {
+  const { status } = useWallet();
+  const config = statusConfig[status];
+
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-300',
+        config.bgColor,
+        config.textColor,
+        className
+      )}
+      role="status"
+      aria-live="polite"
+      aria-label={`Wallet status: ${config.label}`}
+    >
+      <span
+        className={cn(
+          'relative flex h-2.5 w-2.5',
+          (status === 'connecting' || status === 'reconnecting' || status === 'disconnecting') && 'animate-pulse'
+        )}
+      >
+        <span
+          className={cn(
+            'absolute inline-flex h-full w-full rounded-full opacity-75',
+            config.dotColor,
+            (status === 'connecting' || status === 'reconnecting') && 'animate-ping'
+          )}
+        />
+        <span className={cn('relative inline-flex rounded-full h-2.5 w-2.5', config.dotColor)} />
+      </span>
+      <span>{config.label}</span>
+    </div>
+  );
+};
+
+export default WalletStatusPill;

--- a/src/components/wallet/index.ts
+++ b/src/components/wallet/index.ts
@@ -1,0 +1,3 @@
+export { WalletStatusPill } from './WalletStatusPill';
+export { WalletButton } from './WalletButton';
+export type { WalletStatus } from './WalletStatusPill';

--- a/src/contexts/WalletProvider.tsx
+++ b/src/contexts/WalletProvider.tsx
@@ -1,0 +1,26 @@
+import React, { createContext, useContext, ReactNode } from 'react';
+import { useWallet, WalletState, WalletActions } from '../hooks/useWallet';
+
+type WalletContextType = WalletState & WalletActions;
+
+const WalletContext = createContext<WalletContextType | undefined>(undefined);
+
+export const WalletProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const wallet = useWallet();
+  
+  return (
+    <WalletContext.Provider value={wallet}>
+      {children}
+    </WalletContext.Provider>
+  );
+};
+
+export const useWalletContext = (): WalletContextType => {
+  const context = useContext(WalletContext);
+  if (context === undefined) {
+    throw new Error('useWalletContext must be used within a WalletProvider');
+  }
+  return context;
+};
+
+export default WalletProvider;

--- a/src/hooks/useWallet.test.ts
+++ b/src/hooks/useWallet.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useWallet } from './useWallet';
+
+const mockOpenModal = vi.fn();
+const mockGetAddress = vi.fn();
+const mockSetWallet = vi.fn();
+const mockDisconnect = vi.fn();
+
+vi.mock('@creit.tech/stellar-wallets-kit', () => ({
+  StellarWalletsKit: vi.fn().mockImplementation(() => ({
+    openModal: mockOpenModal,
+    getAddress: mockGetAddress,
+    setWallet: mockSetWallet,
+    disconnect: mockDisconnect,
+  })),
+  WalletNetwork: { TESTNET: 'TESTNET' },
+  FREIGHTER_ID: 'freighter',
+  FreighterModule: vi.fn(),
+  xBullModule: vi.fn(),
+  AlbedoModule: vi.fn(),
+}));
+
+describe('useWallet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('initializes with disconnected status', () => {
+    const { result } = renderHook(() => useWallet());
+    expect(result.current.status).toBe('disconnected');
+    expect(result.current.address).toBeNull();
+  });
+
+  it('transitions to connected after successful connection', async () => {
+    mockOpenModal.mockImplementation(({ onWalletSelected }) => {
+      onWalletSelected({ id: 'freighter' });
+    });
+    mockGetAddress.mockResolvedValue({ address: 'GABC123...' });
+
+    const { result } = renderHook(() => useWallet());
+    
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.status).toBe('connected');
+    expect(result.current.address).toBe('GABC123...');
+    expect(localStorage.getItem('walletId')).toBe('freighter');
+  });
+
+  it('transitions to disconnected after disconnect', async () => {
+    mockOpenModal.mockImplementation(({ onWalletSelected }) => {
+      onWalletSelected({ id: 'freighter' });
+    });
+    mockGetAddress.mockResolvedValue({ address: 'GABC123...' });
+
+    const { result } = renderHook(() => useWallet());
+    
+    await act(async () => {
+      await result.current.connect();
+    });
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(result.current.status).toBe('disconnected');
+    expect(localStorage.getItem('walletId')).toBeNull();
+  });
+});

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -1,0 +1,222 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import {
+  StellarWalletsKit,
+  WalletNetwork,
+  ISupportedWallet,
+  FREIGHTER_ID,
+  FreighterModule,
+  xBullModule,
+  AlbedoModule,
+} from '@creit.tech/stellar-wallets-kit';
+
+export type WalletStatus = 'disconnected' | 'connecting' | 'connected' | 'reconnecting' | 'disconnecting' | 'error';
+
+export interface WalletState {
+  status: WalletStatus;
+  address: string | null;
+  walletId: string | null;
+  error: Error | null;
+  kit: StellarWalletsKit | null;
+}
+
+export interface WalletActions {
+  connect: () => Promise<void>;
+  disconnect: () => Promise<void>;
+  reconnect: () => Promise<void>;
+}
+
+let kitInstance: StellarWalletsKit | null = null;
+
+function getKitInstance(): StellarWalletsKit {
+  if (!kitInstance) {
+    kitInstance = new StellarWalletsKit({
+      network: WalletNetwork.TESTNET,
+      selectedWalletId: FREIGHTER_ID,
+      modules: [new FreighterModule(), new xBullModule(), new AlbedoModule()],
+    });
+  }
+  return kitInstance;
+}
+
+export function useWallet(): WalletState & WalletActions {
+  const [status, setStatus] = useState<WalletStatus>('disconnected');
+  const [address, setAddress] = useState<string | null>(null);
+  const [walletId, setWalletId] = useState<string | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [kit, setKit] = useState<StellarWalletsKit | null>(null);
+  
+  const reconnectAttempts = useRef(0);
+  const maxReconnectAttempts = 3;
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Initialize kit on mount
+  useEffect(() => {
+    const instance = getKitInstance();
+    setKit(instance);
+    
+    // Check for existing session
+    const checkExistingSession = async () => {
+      try {
+        const storedWalletId = localStorage.getItem('walletId');
+        const storedAddress = localStorage.getItem('walletAddress');
+        
+        if (storedWalletId && storedAddress) {
+          setStatus('reconnecting');
+          instance.setWallet(storedWalletId);
+          
+          // Verify connection is still valid
+          try {
+            const { address: currentAddress } = await instance.getAddress();
+            if (currentAddress === storedAddress) {
+              setAddress(currentAddress);
+              setWalletId(storedWalletId);
+              setStatus('connected');
+              reconnectAttempts.current = 0;
+            } else {
+              // Address mismatch, clear session
+              localStorage.removeItem('walletId');
+              localStorage.removeItem('walletAddress');
+              setStatus('disconnected');
+            }
+          } catch {
+            // Connection lost, attempt reconnect
+            if (reconnectAttempts.current < maxReconnectAttempts) {
+              reconnectAttempts.current += 1;
+              reconnectTimeoutRef.current = setTimeout(() => {
+                checkExistingSession();
+              }, 2000 * reconnectAttempts.current);
+            } else {
+              setStatus('error');
+              setError(new Error('Failed to reconnect wallet after multiple attempts'));
+              localStorage.removeItem('walletId');
+              localStorage.removeItem('walletAddress');
+            }
+          }
+        }
+      } catch (err) {
+        setStatus('error');
+        setError(err instanceof Error ? err : new Error('Unknown error during session check'));
+      }
+    };
+
+    checkExistingSession();
+
+    return () => {
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const connect = useCallback(async () => {
+    if (!kit) return;
+    
+    setStatus('connecting');
+    setError(null);
+    
+    try {
+      await kit.openModal({
+        onWalletSelected: async (option: ISupportedWallet) => {
+          kit.setWallet(option.id);
+          
+          try {
+            const { address: walletAddress } = await kit.getAddress();
+            setAddress(walletAddress);
+            setWalletId(option.id);
+            setStatus('connected');
+            reconnectAttempts.current = 0;
+            
+            // Persist session
+            localStorage.setItem('walletId', option.id);
+            localStorage.setItem('walletAddress', walletAddress);
+          } catch (err) {
+            setStatus('error');
+            setError(err instanceof Error ? err : new Error('Failed to get wallet address'));
+          }
+        },
+        onClosed: () => {
+          // Only reset to disconnected if it weren't already connected
+          setStatus((current) => (current === 'connecting' ? 'disconnected' : current));
+        },
+      });
+    } catch (err) {
+      setStatus('error');
+      setError(err instanceof Error ? err : new Error('Failed to open wallet modal'));
+    }
+  }, [kit]);
+
+  const disconnect = useCallback(async () => {
+    if (!kit) return;
+    
+    setStatus('disconnecting');
+    
+    try {
+      // Clear persisted session
+      localStorage.removeItem('walletId');
+      localStorage.removeItem('walletAddress');
+      
+      // Reset kit state
+      kit.disconnect();
+      
+      setAddress(null);
+      setWalletId(null);
+      setError(null);
+      reconnectAttempts.current = 0;
+      setStatus('disconnected');
+    } catch (err) {
+      setStatus('error');
+      setError(err instanceof Error ? err : new Error('Failed to disconnect wallet'));
+    }
+  }, [kit]);
+
+  const reconnect = useCallback(async () => {
+    if (!kit || !walletId) return;
+    
+    setStatus('reconnecting');
+    setError(null);
+    
+    try {
+      kit.setWallet(walletId);
+      const { address: walletAddress } = await kit.getAddress();
+      setAddress(walletAddress);
+      setStatus('connected');
+      reconnectAttempts.current = 0;
+      
+      localStorage.setItem('walletAddress', walletAddress);
+    } catch (err) {
+      reconnectAttempts.current += 1;
+      if (reconnectAttempts.current >= maxReconnectAttempts) {
+        setStatus('error');
+        setError(err instanceof Error ? err : new Error('Reconnection failed after maximum attempts'));
+        localStorage.removeItem('walletId');
+        localStorage.removeItem('walletAddress');
+      } else {
+        setStatus('disconnected');
+      }
+    }
+  }, [kit, walletId]);
+
+  // Listen for wallet extension disconnect events
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && status === 'connected') {
+        // Verify connection is still active when tab becomes visible
+        reconnect();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [status, reconnect]);
+
+  return {
+    status,
+    address,
+    walletId,
+    error,
+    kit,
+    connect,
+    disconnect,
+    reconnect,
+  };
+}


### PR DESCRIPTION
Closes #136 

## Changes
New Component: WalletStatusPill — visual pill component showing current wallet status with color-coded indicators
Enhanced Hook: useWallet — expanded state machine with connecting, reconnecting, disconnecting, and error states
New Provider: WalletProvider — React context wrapper for wallet state distribution
Updated Button: WalletButton — integrated status pill and loading states
Tests: Unit tests for WalletStatusPill and useWallet hook

## Summary
Added wallet connection status pill events to display real-time wallet connection transitions in the UI.
-

## Testing
# Install dependencies
pnpm install

# Run tests
pnpm test

# Start dev server
pnpm dev

## Checklist
[x] Scoped change with no unrelated file churn
[x] Status labels are concise (single word or short phrase)
[x] Handles reconnect and disconnect events
[x] Auto-reconnect on page visibility change with 3-attempt limit
[x] Session persistence via localStorage
[x] Accessible with ARIA roles and live regions
[x] Tests included for core functionality

