### PR TITLE
Feature/140 read only banner

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,9 @@
 import { Toaster } from 'react-hot-toast';
 import { createBrowserRouter, RouterProvider } from 'react-router';
 import LandingPage from './pages/LandingPage';
+import { WalletProvider } from './contexts/WalletProvider';
+import { WalletButton } from './components/wallet/WalletButton';
+import { WalletStatusPill } from './components/wallet/WalletStatusPill';
 
 const router = createBrowserRouter([
 	{
@@ -11,7 +14,10 @@ const router = createBrowserRouter([
 
 function App() {
 	return (
+		
 		<>
+		<WalletProvider>
+
 			<Toaster
 				toastOptions={{
 					ariaProps: {
@@ -20,7 +26,10 @@ function App() {
 					},
 				}}
 			/>
+			<WalletStatusPill />
+        <WalletButton />
 			<RouterProvider router={router} />
+			 </WalletProvider>
 		</>
 	);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import LandingPage from './pages/LandingPage';
 import { WalletProvider } from './contexts/WalletProvider';
 import { WalletButton } from './components/wallet/WalletButton';
 import { WalletStatusPill } from './components/wallet/WalletStatusPill';
-
+import { ReadOnlyBanner } from './components/wallet/ReadOnlyBanner';
 const router = createBrowserRouter([
 	{
 		path: '/',
@@ -17,6 +17,8 @@ function App() {
 		
 		<>
 		<WalletProvider>
+
+			        <ReadOnlyBanner />
 
 			<Toaster
 				toastOptions={{

--- a/src/components/wallet/ReadOnlyBanner.test.tsx
+++ b/src/components/wallet/ReadOnlyBanner.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ReadOnlyBanner } from './ReadOnlyBanner';
+import { useWallet } from '../../hooks/useWallet';
+
+vi.mock('../../hooks/useWallet', () => ({
+  useWallet: vi.fn(),
+}));
+
+describe('ReadOnlyBanner', () => {
+  const mockConnect = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders when wallet is disconnected', () => {
+    vi.mocked(useWallet).mockReturnValue({
+      status: 'disconnected',
+      connect: mockConnect,
+    } as any);
+
+    render(<ReadOnlyBanner />);
+    expect(screen.getByText('You are browsing in read-only mode')).toBeInTheDocument();
+    expect(screen.getByText(/Connect your wallet to buy keys/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Connect Wallet/i })).toBeInTheDocument();
+  });
+
+  it('does not render when wallet is connected', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'connected', connect: mockConnect } as any);
+    const { container } = render(<ReadOnlyBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not render when wallet is connecting', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'connecting', connect: mockConnect } as any);
+    const { container } = render(<ReadOnlyBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not render when wallet is reconnecting', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'reconnecting', connect: mockConnect } as any);
+    const { container } = render(<ReadOnlyBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not render when wallet is disconnecting', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'disconnecting', connect: mockConnect } as any);
+    const { container } = render(<ReadOnlyBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('does not render when wallet has error', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'error', connect: mockConnect } as any);
+    const { container } = render(<ReadOnlyBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('calls connect when Connect Wallet button is clicked', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'disconnected', connect: mockConnect } as any);
+    render(<ReadOnlyBanner />);
+    fireEvent.click(screen.getByRole('button', { name: /Connect Wallet/i }));
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('has correct ARIA attributes', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'disconnected', connect: mockConnect } as any);
+    render(<ReadOnlyBanner />);
+    expect(screen.getByRole('banner')).toHaveAttribute('aria-label', 'Read-only mode notification');
+  });
+});

--- a/src/components/wallet/ReadOnlyBanner.tsx
+++ b/src/components/wallet/ReadOnlyBanner.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { useWallet } from '../../hooks/useWallet';
+import { cn } from '../../lib/utils';
+import { Eye, Wallet } from 'lucide-react';
+
+interface ReadOnlyBannerProps {
+  className?: string;
+}
+
+export const ReadOnlyBanner: React.FC<ReadOnlyBannerProps> = ({ className }) => {
+  const { status, connect } = useWallet();
+
+  // Only show when wallet is disconnected
+  if (status !== 'disconnected') {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        'w-full bg-amber-50 border-b border-amber-200 px-4 py-3',
+        className
+      )}
+      role="banner"
+      aria-label="Read-only mode notification"
+    >
+      <div className="max-w-7xl mx-auto flex items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div className="flex-shrink-0 w-8 h-8 rounded-full bg-amber-100 flex items-center justify-center">
+            <Eye className="w-4 h-4 text-amber-700" aria-hidden="true" />
+          </div>
+          <div className="flex flex-col">
+            <span className="text-sm font-semibold text-amber-900">
+              You are browsing in read-only mode
+            </span>
+            <span className="text-xs text-amber-700">
+              Connect your wallet to buy keys, unlock perks, and interact with creators.
+            </span>
+          </div>
+        </div>
+
+        <button
+          onClick={connect}
+          className={cn(
+            'flex-shrink-0 inline-flex items-center gap-2 px-4 py-2 rounded-lg',
+            'text-sm font-medium text-white bg-amber-600 hover:bg-amber-700',
+            'focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2',
+            'transition-colors duration-200'
+          )}
+        >
+          <Wallet className="w-4 h-4" aria-hidden="true" />
+          Connect Wallet
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ReadOnlyBanner;

--- a/src/components/wallet/WalletButton.tsx
+++ b/src/components/wallet/WalletButton.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { useWallet } from '../../hooks/useWallet';
+import { WalletStatusPill } from './WalletStatusPill';
+import { cn } from '../../lib/utils';
+
+interface WalletButtonProps {
+  className?: string;
+  showStatusPill?: boolean;
+}
+
+export const WalletButton: React.FC<WalletButtonProps> = ({ 
+  className,
+  showStatusPill = true 
+}) => {
+  const { status, address, connect, disconnect } = useWallet();
+
+  const isConnected = status === 'connected';
+  const isLoading = status === 'connecting' || status === 'reconnecting' || status === 'disconnecting';
+
+  const handleClick = () => {
+    if (isConnected) {
+      disconnect();
+    } else {
+      connect();
+    }
+  };
+
+  const formatAddress = (addr: string | null) => {
+    if (!addr) return '';
+    return `${addr.slice(0, 4)}...${addr.slice(-4)}`;
+  };
+
+  return (
+    <div className={cn('flex items-center gap-3', className)}>
+      {showStatusPill && <WalletStatusPill />}
+      
+      <button
+        onClick={handleClick}
+        disabled={isLoading}
+        className={cn(
+          'px-4 py-2 rounded-lg font-medium text-sm transition-all duration-200',
+          'focus:outline-none focus:ring-2 focus:ring-offset-2',
+          isConnected
+            ? 'bg-slate-800 text-white hover:bg-slate-700 focus:ring-slate-500'
+            : 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500',
+          isLoading && 'opacity-70 cursor-not-allowed',
+          'disabled:opacity-50'
+        )}
+        aria-busy={isLoading}
+      >
+        {isLoading ? (
+          <span className="flex items-center gap-2">
+            <svg className="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+            </svg>
+            {status === 'connecting' && 'Connecting...'}
+            {status === 'reconnecting' && 'Reconnecting...'}
+            {status === 'disconnecting' && 'Disconnecting...'}
+          </span>
+        ) : isConnected ? (
+          <span className="flex items-center gap-2">
+            <span className="w-2 h-2 bg-emerald-400 rounded-full" />
+            {formatAddress(address)}
+          </span>
+        ) : (
+          'Connect Wallet'
+        )}
+      </button>
+    </div>
+  );
+};
+
+export default WalletButton;

--- a/src/components/wallet/WalletStatusPill.test.tsx
+++ b/src/components/wallet/WalletStatusPill.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { WalletStatusPill } from './WalletStatusPill';
+import { useWallet } from '../../hooks/useWallet';
+
+vi.mock('../../hooks/useWallet', () => ({
+  useWallet: vi.fn(),
+}));
+
+describe('WalletStatusPill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders disconnected status', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'disconnected' } as any);
+    render(<WalletStatusPill />);
+    expect(screen.getByText('Disconnected')).toBeInTheDocument();
+  });
+
+  it('renders connecting status', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'connecting' } as any);
+    render(<WalletStatusPill />);
+    expect(screen.getByText('Connecting...')).toBeInTheDocument();
+  });
+
+  it('renders connected status', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'connected' } as any);
+    render(<WalletStatusPill />);
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+  });
+
+  it('renders reconnecting status', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'reconnecting' } as any);
+    render(<WalletStatusPill />);
+    expect(screen.getByText('Reconnecting...')).toBeInTheDocument();
+  });
+
+  it('renders disconnecting status', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'disconnecting' } as any);
+    render(<WalletStatusPill />);
+    expect(screen.getByText('Disconnecting...')).toBeInTheDocument();
+  });
+
+  it('renders error status', () => {
+    vi.mocked(useWallet).mockReturnValue({ status: 'error' } as any);
+    render(<WalletStatusPill />);
+    expect(screen.getByText('Connection Error')).toBeInTheDocument();
+  });
+});

--- a/src/components/wallet/WalletStatusPill.tsx
+++ b/src/components/wallet/WalletStatusPill.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { useWallet } from '../../hooks/useWallet';
+import { cn } from '../../lib/utils';
+
+export type WalletStatus = 'disconnected' | 'connecting' | 'connected' | 'reconnecting' | 'disconnecting' | 'error';
+
+interface WalletStatusPillProps {
+  className?: string;
+}
+
+const statusConfig: Record<WalletStatus, { label: string; dotColor: string; bgColor: string; textColor: string }> = {
+  disconnected: {
+    label: 'Disconnected',
+    dotColor: 'bg-gray-400',
+    bgColor: 'bg-gray-100',
+    textColor: 'text-gray-600',
+  },
+  connecting: {
+    label: 'Connecting...',
+    dotColor: 'bg-yellow-400',
+    bgColor: 'bg-yellow-50',
+    textColor: 'text-yellow-700',
+  },
+  connected: {
+    label: 'Connected',
+    dotColor: 'bg-emerald-500',
+    bgColor: 'bg-emerald-50',
+    textColor: 'text-emerald-700',
+  },
+  reconnecting: {
+    label: 'Reconnecting...',
+    dotColor: 'bg-amber-400',
+    bgColor: 'bg-amber-50',
+    textColor: 'text-amber-700',
+  },
+  disconnecting: {
+    label: 'Disconnecting...',
+    dotColor: 'bg-orange-400',
+    bgColor: 'bg-orange-50',
+    textColor: 'text-orange-700',
+  },
+  error: {
+    label: 'Connection Error',
+    dotColor: 'bg-red-500',
+    bgColor: 'bg-red-50',
+    textColor: 'text-red-700',
+  },
+};
+
+export const WalletStatusPill: React.FC<WalletStatusPillProps> = ({ className }) => {
+  const { status } = useWallet();
+  const config = statusConfig[status];
+
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium transition-all duration-300',
+        config.bgColor,
+        config.textColor,
+        className
+      )}
+      role="status"
+      aria-live="polite"
+      aria-label={`Wallet status: ${config.label}`}
+    >
+      <span
+        className={cn(
+          'relative flex h-2.5 w-2.5',
+          (status === 'connecting' || status === 'reconnecting' || status === 'disconnecting') && 'animate-pulse'
+        )}
+      >
+        <span
+          className={cn(
+            'absolute inline-flex h-full w-full rounded-full opacity-75',
+            config.dotColor,
+            (status === 'connecting' || status === 'reconnecting') && 'animate-ping'
+          )}
+        />
+        <span className={cn('relative inline-flex rounded-full h-2.5 w-2.5', config.dotColor)} />
+      </span>
+      <span>{config.label}</span>
+    </div>
+  );
+};
+
+export default WalletStatusPill;

--- a/src/components/wallet/index.ts
+++ b/src/components/wallet/index.ts
@@ -1,0 +1,3 @@
+export { WalletStatusPill } from './WalletStatusPill';
+export { WalletButton } from './WalletButton';
+export type { WalletStatus } from './WalletStatusPill';

--- a/src/components/wallet/index.ts
+++ b/src/components/wallet/index.ts
@@ -1,3 +1,4 @@
 export { WalletStatusPill } from './WalletStatusPill';
 export { WalletButton } from './WalletButton';
 export type { WalletStatus } from './WalletStatusPill';
+export { ReadOnlyBanner } from './ReadOnlyBanner';

--- a/src/contexts/WalletProvider.tsx
+++ b/src/contexts/WalletProvider.tsx
@@ -1,0 +1,26 @@
+import React, { createContext, useContext, ReactNode } from 'react';
+import { useWallet, WalletState, WalletActions } from '../hooks/useWallet';
+
+type WalletContextType = WalletState & WalletActions;
+
+const WalletContext = createContext<WalletContextType | undefined>(undefined);
+
+export const WalletProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const wallet = useWallet();
+  
+  return (
+    <WalletContext.Provider value={wallet}>
+      {children}
+    </WalletContext.Provider>
+  );
+};
+
+export const useWalletContext = (): WalletContextType => {
+  const context = useContext(WalletContext);
+  if (context === undefined) {
+    throw new Error('useWalletContext must be used within a WalletProvider');
+  }
+  return context;
+};
+
+export default WalletProvider;

--- a/src/hooks/useWallet.test.ts
+++ b/src/hooks/useWallet.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useWallet } from './useWallet';
+
+const mockOpenModal = vi.fn();
+const mockGetAddress = vi.fn();
+const mockSetWallet = vi.fn();
+const mockDisconnect = vi.fn();
+
+vi.mock('@creit.tech/stellar-wallets-kit', () => ({
+  StellarWalletsKit: vi.fn().mockImplementation(() => ({
+    openModal: mockOpenModal,
+    getAddress: mockGetAddress,
+    setWallet: mockSetWallet,
+    disconnect: mockDisconnect,
+  })),
+  WalletNetwork: { TESTNET: 'TESTNET' },
+  FREIGHTER_ID: 'freighter',
+  FreighterModule: vi.fn(),
+  xBullModule: vi.fn(),
+  AlbedoModule: vi.fn(),
+}));
+
+describe('useWallet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('initializes with disconnected status', () => {
+    const { result } = renderHook(() => useWallet());
+    expect(result.current.status).toBe('disconnected');
+    expect(result.current.address).toBeNull();
+  });
+
+  it('transitions to connected after successful connection', async () => {
+    mockOpenModal.mockImplementation(({ onWalletSelected }) => {
+      onWalletSelected({ id: 'freighter' });
+    });
+    mockGetAddress.mockResolvedValue({ address: 'GABC123...' });
+
+    const { result } = renderHook(() => useWallet());
+    
+    await act(async () => {
+      await result.current.connect();
+    });
+
+    expect(result.current.status).toBe('connected');
+    expect(result.current.address).toBe('GABC123...');
+    expect(localStorage.getItem('walletId')).toBe('freighter');
+  });
+
+  it('transitions to disconnected after disconnect', async () => {
+    mockOpenModal.mockImplementation(({ onWalletSelected }) => {
+      onWalletSelected({ id: 'freighter' });
+    });
+    mockGetAddress.mockResolvedValue({ address: 'GABC123...' });
+
+    const { result } = renderHook(() => useWallet());
+    
+    await act(async () => {
+      await result.current.connect();
+    });
+    await act(async () => {
+      await result.current.disconnect();
+    });
+
+    expect(result.current.status).toBe('disconnected');
+    expect(localStorage.getItem('walletId')).toBeNull();
+  });
+});

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -1,0 +1,222 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import {
+  StellarWalletsKit,
+  WalletNetwork,
+  ISupportedWallet,
+  FREIGHTER_ID,
+  FreighterModule,
+  xBullModule,
+  AlbedoModule,
+} from '@creit.tech/stellar-wallets-kit';
+
+export type WalletStatus = 'disconnected' | 'connecting' | 'connected' | 'reconnecting' | 'disconnecting' | 'error';
+
+export interface WalletState {
+  status: WalletStatus;
+  address: string | null;
+  walletId: string | null;
+  error: Error | null;
+  kit: StellarWalletsKit | null;
+}
+
+export interface WalletActions {
+  connect: () => Promise<void>;
+  disconnect: () => Promise<void>;
+  reconnect: () => Promise<void>;
+}
+
+let kitInstance: StellarWalletsKit | null = null;
+
+function getKitInstance(): StellarWalletsKit {
+  if (!kitInstance) {
+    kitInstance = new StellarWalletsKit({
+      network: WalletNetwork.TESTNET,
+      selectedWalletId: FREIGHTER_ID,
+      modules: [new FreighterModule(), new xBullModule(), new AlbedoModule()],
+    });
+  }
+  return kitInstance;
+}
+
+export function useWallet(): WalletState & WalletActions {
+  const [status, setStatus] = useState<WalletStatus>('disconnected');
+  const [address, setAddress] = useState<string | null>(null);
+  const [walletId, setWalletId] = useState<string | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [kit, setKit] = useState<StellarWalletsKit | null>(null);
+  
+  const reconnectAttempts = useRef(0);
+  const maxReconnectAttempts = 3;
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Initialize kit on mount
+  useEffect(() => {
+    const instance = getKitInstance();
+    setKit(instance);
+    
+    // Check for existing session
+    const checkExistingSession = async () => {
+      try {
+        const storedWalletId = localStorage.getItem('walletId');
+        const storedAddress = localStorage.getItem('walletAddress');
+        
+        if (storedWalletId && storedAddress) {
+          setStatus('reconnecting');
+          instance.setWallet(storedWalletId);
+          
+          // Verify connection is still valid
+          try {
+            const { address: currentAddress } = await instance.getAddress();
+            if (currentAddress === storedAddress) {
+              setAddress(currentAddress);
+              setWalletId(storedWalletId);
+              setStatus('connected');
+              reconnectAttempts.current = 0;
+            } else {
+              // Address mismatch, clear session
+              localStorage.removeItem('walletId');
+              localStorage.removeItem('walletAddress');
+              setStatus('disconnected');
+            }
+          } catch {
+            // Connection lost, attempt reconnect
+            if (reconnectAttempts.current < maxReconnectAttempts) {
+              reconnectAttempts.current += 1;
+              reconnectTimeoutRef.current = setTimeout(() => {
+                checkExistingSession();
+              }, 2000 * reconnectAttempts.current);
+            } else {
+              setStatus('error');
+              setError(new Error('Failed to reconnect wallet after multiple attempts'));
+              localStorage.removeItem('walletId');
+              localStorage.removeItem('walletAddress');
+            }
+          }
+        }
+      } catch (err) {
+        setStatus('error');
+        setError(err instanceof Error ? err : new Error('Unknown error during session check'));
+      }
+    };
+
+    checkExistingSession();
+
+    return () => {
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const connect = useCallback(async () => {
+    if (!kit) return;
+    
+    setStatus('connecting');
+    setError(null);
+    
+    try {
+      await kit.openModal({
+        onWalletSelected: async (option: ISupportedWallet) => {
+          kit.setWallet(option.id);
+          
+          try {
+            const { address: walletAddress } = await kit.getAddress();
+            setAddress(walletAddress);
+            setWalletId(option.id);
+            setStatus('connected');
+            reconnectAttempts.current = 0;
+            
+            // Persist session
+            localStorage.setItem('walletId', option.id);
+            localStorage.setItem('walletAddress', walletAddress);
+          } catch (err) {
+            setStatus('error');
+            setError(err instanceof Error ? err : new Error('Failed to get wallet address'));
+          }
+        },
+        onClosed: () => {
+          // Only reset to disconnected if it weren't already connected
+          setStatus((current) => (current === 'connecting' ? 'disconnected' : current));
+        },
+      });
+    } catch (err) {
+      setStatus('error');
+      setError(err instanceof Error ? err : new Error('Failed to open wallet modal'));
+    }
+  }, [kit]);
+
+  const disconnect = useCallback(async () => {
+    if (!kit) return;
+    
+    setStatus('disconnecting');
+    
+    try {
+      // Clear persisted session
+      localStorage.removeItem('walletId');
+      localStorage.removeItem('walletAddress');
+      
+      // Reset kit state
+      kit.disconnect();
+      
+      setAddress(null);
+      setWalletId(null);
+      setError(null);
+      reconnectAttempts.current = 0;
+      setStatus('disconnected');
+    } catch (err) {
+      setStatus('error');
+      setError(err instanceof Error ? err : new Error('Failed to disconnect wallet'));
+    }
+  }, [kit]);
+
+  const reconnect = useCallback(async () => {
+    if (!kit || !walletId) return;
+    
+    setStatus('reconnecting');
+    setError(null);
+    
+    try {
+      kit.setWallet(walletId);
+      const { address: walletAddress } = await kit.getAddress();
+      setAddress(walletAddress);
+      setStatus('connected');
+      reconnectAttempts.current = 0;
+      
+      localStorage.setItem('walletAddress', walletAddress);
+    } catch (err) {
+      reconnectAttempts.current += 1;
+      if (reconnectAttempts.current >= maxReconnectAttempts) {
+        setStatus('error');
+        setError(err instanceof Error ? err : new Error('Reconnection failed after maximum attempts'));
+        localStorage.removeItem('walletId');
+        localStorage.removeItem('walletAddress');
+      } else {
+        setStatus('disconnected');
+      }
+    }
+  }, [kit, walletId]);
+
+  // Listen for wallet extension disconnect events
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && status === 'connected') {
+        // Verify connection is still active when tab becomes visible
+        reconnect();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [status, reconnect]);
+
+  return {
+    status,
+    address,
+    walletId,
+    error,
+    kit,
+    connect,
+    disconnect,
+    reconnect,
+  };
+}


### PR DESCRIPTION
Closes #140    


## Summary
Add a read-only banner that displays when the wallet is disconnected, keeping browse capabilities enabled while encouraging wallet connection.

## Changes
- New Component: ReadOnlyBanner
- Updated Exports: added ReadOnlyBanner to wallet barrel
- Tests: Unit tests for all 6 wallet states

## Behavior
- Shows amber banner with "Connect Wallet" CTA when disconnected
- Hides automatically on connect/reconnect
- No blocking of browse functionality

Closes #140
Depends on #136