### PR TITLE
feat: add Esc keyboard hint support for dialogs

### DIFF
--- a/src/components/common/PendingTxModal.tsx
+++ b/src/components/common/PendingTxModal.tsx
@@ -52,6 +52,7 @@ const PendingTxModal: React.FC<PendingTxModalProps> = ({
 		<Dialog open={open} onOpenChange={handleOpenChange}>
 			<DialogContent
 				showCloseButton={!(blockDismissal && isLoading)}
+				showEscapeHint={!(blockDismissal && isLoading)}
 				className="max-w-sm"
 				// Prevent closing via Escape when dismissal is blocked
 				onEscapeKeyDown={(e: KeyboardEvent) => {

--- a/src/components/common/TradeDialog.tsx
+++ b/src/components/common/TradeDialog.tsx
@@ -59,6 +59,7 @@ const TradeDialog: React.FC<TradeDialogProps> = ({
 			<DialogContent
 				className="max-w-md"
 				showCloseButton={!isSubmitting}
+				showEscapeHint={!isSubmitting}
 				onOpenAutoFocus={event => {
 					event.preventDefault();
 					amountInputRef.current?.focus();
@@ -154,4 +155,3 @@ const TradeDialog: React.FC<TradeDialogProps> = ({
 };
 
 export default TradeDialog;
-

--- a/src/components/ui/dialog.test.tsx
+++ b/src/components/ui/dialog.test.tsx
@@ -17,4 +17,24 @@ describe('DialogContent', () => {
 		);
 		expect(content.className).toContain('sm:pb-6');
 	});
+
+	it('shows the escape hint by default', () => {
+		render(
+			<Dialog open>
+				<DialogContent>Dialog body</DialogContent>
+			</Dialog>
+		);
+
+		expect(screen.getByText('Esc to close')).toBeInTheDocument();
+	});
+
+	it('hides the escape hint when explicitly disabled', () => {
+		render(
+			<Dialog open>
+				<DialogContent showEscapeHint={false}>Dialog body</DialogContent>
+			</Dialog>
+		);
+
+		expect(screen.queryByText('Esc to close')).not.toBeInTheDocument();
+	});
 });

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -49,9 +49,11 @@ function DialogContent({
 	className,
 	children,
 	showCloseButton = true,
+	showEscapeHint = true,
 	...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
 	showCloseButton?: boolean;
+	showEscapeHint?: boolean;
 }) {
 	return (
 		<DialogPortal data-slot="dialog-portal">
@@ -65,6 +67,14 @@ function DialogContent({
 				{...props}
 			>
 				{children}
+				{showEscapeHint && (
+					<p
+						aria-hidden="true"
+						className="pointer-events-none absolute right-4 bottom-3 select-none text-[11px] text-white/45"
+					>
+						Esc to close
+					</p>
+				)}
 				{showCloseButton && (
 					<DialogPrimitive.Close
 						data-slot="dialog-close"


### PR DESCRIPTION
## Summary
- add a reusable keyboard hint (`Esc to close`) inside dialog content for open dialog contexts
- render hint as an absolute, non-interactive overlay so layout flow is unchanged
- add `showEscapeHint` opt-out prop on `DialogContent` for contexts where Escape dismissal is intentionally blocked
- wire opt-out in guarded dialog states (`TradeDialog` while submitting, `PendingTxModal` while blocked/loading)
- add focused unit tests covering default visible hint and disabled-hint behavior

## Validation
- `npm test -- src/components/ui/dialog.test.tsx` *(fails locally: `vitest` not found in this clone environment)*

Closes #223
Closes #224
Closes #227
Closes #229
