### PR TITLE
feat: add fallback copy when creator avatar image fails to load

### DIFF
--- a/src/components/common/CreatorInitialsAvatar.tsx
+++ b/src/components/common/CreatorInitialsAvatar.tsx
@@ -38,8 +38,10 @@ const CreatorInitialsAvatar: React.FC<CreatorInitialsAvatarProps> = ({
 	if (!imageSrc || hasError) {
 		return (
 			<div
+				role="img"
+				aria-label={`${name} avatar`}
 				className={cn(
-					'flex size-full items-center justify-center text-3xl font-black tracking-wide',
+					'flex size-full flex-col items-center justify-center gap-0.5 text-3xl font-black tracking-wide',
 					className
 				)}
 				style={{
@@ -47,7 +49,12 @@ const CreatorInitialsAvatar: React.FC<CreatorInitialsAvatarProps> = ({
 					color: fallbackColors.textColor,
 				}}
 			>
-				<span aria-label={`${name} initials avatar`}>{initials}</span>
+				<span aria-hidden="true">{initials}</span>
+				{hasError && (
+					<span className="text-[0.5rem] font-semibold uppercase tracking-widest opacity-60">
+						No image
+					</span>
+				)}
 			</div>
 		);
 	}
@@ -55,7 +62,7 @@ const CreatorInitialsAvatar: React.FC<CreatorInitialsAvatarProps> = ({
 	return (
 		<img
 			src={imageSrc}
-			alt={name}
+			alt={`${name} avatar`}
 			onError={() => setHasError(true)}
 			className={cn('size-full object-cover', imageClassName, className)}
 		/>


### PR DESCRIPTION
## Summary

Adds clear fallback copy and state handling when creator avatar images fail to load.

## Changes

- Updated `CreatorInitialsAvatar` to show a concise `No image` label below the initials when the image `src` fails to load
- Added `role="img"` and `aria-label` on the fallback container for screen-reader accessibility
- Improved `alt` text on the `<img>` element to include `avatar` context
- Fallback stays within the same `size-full` container — no layout shift

## Testing

- Lint: passes (`pnpm lint`)
- TypeScript: passes (`tsc -b`)
- Verified visually: broken image URL triggers initials + 'No image' label; valid image renders normally

Closes #172