### PR TITLE
feat: add empty holdings illustration alt text accessibility pass

### DIFF
--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -23,13 +23,16 @@ const EmptyState: React.FC<EmptyStateProps> = ({
 				'flex flex-col items-center justify-center rounded-[2rem] border border-white/10 bg-white/5 px-8 py-14 text-center backdrop-blur-xl',
 				className
 			)}
+			role="status"
+			aria-label={title}
 		>
 			<div className="relative mb-6">
 				<div className="absolute inset-0 size-full rounded-full bg-amber-500/10 blur-2xl" />
 				<img
 					src={image}
 					className="relative z-10 size-[180px] object-contain opacity-60 grayscale transition-all duration-500 hover:opacity-80 hover:grayscale-0"
-					alt={title}
+					alt=""
+					aria-hidden="true"
 				/>
 			</div>
 			<h2 className="font-grotesque text-2xl font-black tracking-tight text-white mb-2">
@@ -43,9 +46,10 @@ const EmptyState: React.FC<EmptyStateProps> = ({
 				<Button
 					onClick={onReset}
 					variant="outline"
+					aria-label="Reset search results"
 					className="rounded-xl border-white/10 bg-white/5 px-6 font-bold text-white transition-all hover:border-amber-500/30 hover:bg-amber-500/10"
 				>
-					<RotateCcw className="mr-2 size-4" />
+					<RotateCcw className="mr-2 size-4" aria-hidden="true" />
 					Reset Search
 				</Button>
 			)}


### PR DESCRIPTION
## Summary

Improves accessibility for empty holdings visuals by adding clear alt text and semantic labeling.

## Changes

- `EmptyState`: illustration image is now marked as decorative (`alt=""`, `aria-hidden="true"`) — the title text already describes the state, so the image should not be announced redundantly
- Added `role="status"` and `aria-label={title}` on the container so screen readers announce the empty state correctly
- Added `aria-label="Reset search results"` on the CTA button for explicit action labeling
- Added `aria-hidden="true"` on the decorative `RotateCcw` icon

## Testing

- Lint: passes (`pnpm lint`)
- TypeScript: passes (`tsc -b`)
- Keyboard/screen-reader flow: container announces state title; CTA is labeled; decorative image is silent

Closes #171