### PR TITLE
fix: creator UI polish — separator opacity, stat width, category fallback, focus ring offset

### DIFF
--- a/src/components/common/CategoryTag.tsx
+++ b/src/components/common/CategoryTag.tsx
@@ -6,7 +6,7 @@ interface CategoryTagProps {
 }
 
 const CategoryTag: React.FC<CategoryTagProps> = ({
-	label = 'Uncategorized',
+	label = 'No category',
 	className,
 }) => {
 	return (

--- a/src/components/common/CreatorListRowDivider.tsx
+++ b/src/components/common/CreatorListRowDivider.tsx
@@ -10,7 +10,7 @@ const CreatorListRowDivider: React.FC<CreatorListRowDividerProps> = ({
 	return (
 		<div
 			className={cn(
-				'h-px w-full bg-gradient-to-r from-transparent via-white/10 to-transparent',
+				'h-px w-full bg-gradient-to-r from-transparent via-white/[0.08] to-transparent',
 				className
 			)}
 			aria-hidden="true"

--- a/src/components/common/CreatorProfileStatItem.tsx
+++ b/src/components/common/CreatorProfileStatItem.tsx
@@ -23,7 +23,7 @@ const CreatorProfileStatItem: React.FC<CreatorProfileStatItemProps> = ({
 			<p className="relative z-10 text-[0.65rem] font-bold uppercase tracking-[0.22em] text-white/40 transition-colors duration-300 group-hover:text-amber-200/50">
 				{label}
 			</p>
-			<div className="relative z-10 mt-2.5 font-jakarta text-base font-bold text-white md:text-[1.05rem]">
+			<div className="relative z-10 mt-2.5 min-w-[4rem] font-jakarta text-base font-bold text-white md:text-[1.05rem]">
 				{value}
 			</div>
 		</div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] focus-visible:ring-offset-2 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
 	{
 		variants: {
 			variant: {


### PR DESCRIPTION
Closes #260
Closes #261
Closes #262
Closes #263

## Changes

- **#261** `CreatorListRowDivider` — unified separator opacity to `via-white/[0.08]` across all creator link row instances
- **#260** `CreatorProfileStatItem` — added `min-w-[4rem]` to the value container so empty stat values hold their layout footprint
- **#262** `CategoryTag` — updated default fallback label from `'Uncategorized'` to `'No category'` for a cleaner empty state
- **#263** `button.tsx` — added `focus-visible:ring-offset-2` to `buttonVariants` base so all creator action buttons share a consistent focus ring offset

