### PR TITLE
add follower count empty-state helper text

### DIFF
--- a/src/components/common/CreatorProfileInfoGrid.tsx
+++ b/src/components/common/CreatorProfileInfoGrid.tsx
@@ -5,6 +5,7 @@ import CreatorProfileStatItem from './CreatorProfileStatItem';
 interface CreatorProfileInfoItem {
 	label: string;
 	value: ReactNode;
+	helperText?: ReactNode;
 }
 
 interface CreatorProfileInfoGridProps {
@@ -28,6 +29,7 @@ const CreatorProfileInfoGrid: React.FC<CreatorProfileInfoGridProps> = ({
 					key={item.label}
 					label={item.label}
 					value={item.value}
+					helperText={item.helperText}
 				/>
 			))}
 		</div>

--- a/src/components/common/CreatorProfileStatItem.tsx
+++ b/src/components/common/CreatorProfileStatItem.tsx
@@ -4,12 +4,14 @@ import { cn } from '@/lib/utils';
 interface CreatorProfileStatItemProps {
 	label: string;
 	value: ReactNode;
+	helperText?: ReactNode;
 	className?: string;
 }
 
 const CreatorProfileStatItem: React.FC<CreatorProfileStatItemProps> = ({
 	label,
 	value,
+	helperText,
 	className,
 }) => {
 	return (
@@ -26,6 +28,11 @@ const CreatorProfileStatItem: React.FC<CreatorProfileStatItemProps> = ({
 			<div className="relative z-10 mt-2.5 font-jakarta text-base font-bold text-white md:text-[1.05rem]">
 				{value}
 			</div>
+			{helperText && (
+				<p className="relative z-10 mt-1.5 text-xs text-white/45">
+					{helperText}
+				</p>
+			)}
 		</div>
 	);
 };

--- a/src/components/common/__tests__/CreatorProfileStatItem.test.tsx
+++ b/src/components/common/__tests__/CreatorProfileStatItem.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import CreatorProfileStatItem from '../CreatorProfileStatItem';
+
+describe('CreatorProfileStatItem', () => {
+	it('renders helper text beneath the value when provided', () => {
+		render(
+			<CreatorProfileStatItem
+				label="Followers"
+				value="Not available"
+				helperText="Follower count not available yet."
+			/>
+		);
+
+		expect(screen.getByText('Followers')).toBeInTheDocument();
+		expect(screen.getByText('Not available')).toBeInTheDocument();
+		expect(
+			screen.getByText('Follower count not available yet.')
+		).toBeInTheDocument();
+	});
+
+	it('omits helper text when not provided', () => {
+		render(<CreatorProfileStatItem label="Followers" value="12.4K" />);
+
+		expect(
+			screen.queryByText('Follower count not available yet.')
+		).not.toBeInTheDocument();
+	});
+});

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -35,6 +35,8 @@ const FEATURED_CREATOR_FACTS = [
 	{ label: 'Community', value: 'Private behind-the-scenes notes' },
 ];
 
+const FEATURED_CREATOR_FOLLOWER_COUNT: number | null = null;
+
 // Fallback demo data in case API fails
 const DEMO_CREATORS: Course[] = [
 	{
@@ -598,6 +600,19 @@ function LandingPage() {
 						<CreatorProfileInfoGrid
 							items={[
 								...FEATURED_CREATOR_FACTS,
+								{
+									label: 'Followers',
+									value:
+										FEATURED_CREATOR_FOLLOWER_COUNT != null
+											? formatCompactNumber(
+													FEATURED_CREATOR_FOLLOWER_COUNT
+												)
+											: 'Not available',
+									helperText:
+										FEATURED_CREATOR_FOLLOWER_COUNT != null
+											? undefined
+											: 'Follower count not available yet.',
+								},
 								{
 									label: 'Your holdings',
 									value: `${formatNumber(featuredHoldings)} keys`,


### PR DESCRIPTION
Show explicit fallback helper text when follower count is missing in the creator profile facts surface so the UI avoids ambiguous blank states.

## Summary

-

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm build`

## Checklist

- [ ] Linked issue or backlog item
- [ ] Scope is limited to the stated change
- [ ] Updated docs if behavior or setup changed
- [ ] Added screenshots for UI changes when relevant

closes #256