### PR TITLE
feat(a11y/ui): profile header skeleton, accessible metric tooltips, bio clamp, onboarding placeholders (#291/#290/#282/#273)

### DIFF
--- a/src/components/common/AccessibleInfoTrigger.tsx
+++ b/src/components/common/AccessibleInfoTrigger.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { Info } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface AccessibleInfoTriggerProps {
+	/** The explanatory text revealed on focus / hover / click. */
+	explanation: string;
+	/**
+	 * Accessible label for the trigger button. Defaults to a generic phrasing —
+	 * pass a metric-specific label (e.g. `Explanation for: Audience`) so screen
+	 * readers describe *what* the trigger explains.
+	 */
+	label?: string;
+	className?: string;
+}
+
+/**
+ * Accessible tooltip trigger for creator metric explanations (#290).
+ *
+ * Why a new component instead of reusing `<Tooltip>`:
+ * - The existing tooltip wraps content in a non-focusable `<div>` and toggles
+ *   visibility via `group-hover:` / `group-focus-within:`. That works only if
+ *   a focusable descendant exists inside the wrapper, so attaching it to a
+ *   plain label produces a hover-only tooltip.
+ * - Metric explanations need to be reachable via keyboard. A real `<button>`
+ *   with `aria-describedby` pointing to a `role="tooltip"` element is the
+ *   standard accessible pattern and is what assistive tech expects.
+ *
+ * Behaviour:
+ * - Focus / hover / click reveals the tooltip; Escape, blur, or mouse-leave
+ *   hides it. The Escape handler is bound to the trigger itself so it does
+ *   not leak to global keyboard handlers.
+ * - The trigger keeps the same visual footprint whether the tooltip is open
+ *   or not (the popover is absolutely positioned).
+ * - The tooltip content sits below the trigger by default; pass a custom
+ *   `className` if you need to flip positioning.
+ */
+export const AccessibleInfoTrigger: React.FC<AccessibleInfoTriggerProps> = ({
+	explanation,
+	label,
+	className,
+}) => {
+	const tooltipId = React.useId();
+	const [open, setOpen] = React.useState(false);
+
+	const show = React.useCallback(() => setOpen(true), []);
+	const hide = React.useCallback(() => setOpen(false), []);
+	const toggle = React.useCallback(() => setOpen(prev => !prev), []);
+
+	const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>) => {
+		if (event.key === 'Escape' && open) {
+			event.stopPropagation();
+			hide();
+		}
+	};
+
+	return (
+		<span className={cn('relative inline-flex', className)}>
+			<button
+				type="button"
+				aria-label={label ?? 'Show explanation'}
+				aria-describedby={open ? tooltipId : undefined}
+				aria-expanded={open}
+				onMouseEnter={show}
+				onMouseLeave={hide}
+				onFocus={show}
+				onBlur={hide}
+				onClick={toggle}
+				onKeyDown={handleKeyDown}
+				className="inline-flex size-4 items-center justify-center rounded-full text-white/55 transition-colors hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60 focus-visible:ring-offset-1 focus-visible:ring-offset-slate-950"
+			>
+				<Info className="size-3" aria-hidden="true" />
+			</button>
+			{open && (
+				<span
+					id={tooltipId}
+					role="tooltip"
+					className="absolute left-1/2 top-full z-50 mt-2 w-max max-w-xs -translate-x-1/2 rounded-md border border-white/10 bg-slate-950/95 px-2.5 py-1.5 text-[0.7rem] font-medium leading-snug text-white/85 shadow-lg backdrop-blur"
+				>
+					{explanation}
+				</span>
+			)}
+		</span>
+	);
+};
+
+export default AccessibleInfoTrigger;

--- a/src/components/common/CreatorBio.tsx
+++ b/src/components/common/CreatorBio.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils';
+import { lineClampClassFor } from '@/utils/lineClamp.utils';
 
 interface CreatorBioProps {
 	/** Raw bio string from the creator profile. Anything falsy or whitespace-only is treated as missing. */
@@ -9,10 +10,29 @@ interface CreatorBioProps {
 	variant?: 'card' | 'profile';
 	/** If true, returns null instead of a fallback when bio is missing. */
 	allowEmpty?: boolean;
+	/**
+	 * When true and `bio` is empty, swap the generic "no bio" fallback for
+	 * the pending-onboarding placeholder (#291) so visitors know the creator
+	 * is still setting things up rather than seeing a blank section.
+	 */
+	isOnboardingPending?: boolean;
+	/**
+	 * Clamp the rendered bio to at most this many lines on the card (#282).
+	 * Only effective for the `card` variant — the `profile` variant always
+	 * shows the full bio, so the truncation stays purely cosmetic and the
+	 * full text remains accessible on the creator profile page.
+	 *
+	 * Pass `null` (or omit) to disable clamping; the default is `3` lines on
+	 * the card, which matches the card grid's row height and keeps layouts
+	 * uniform across varying bio lengths. Short bios are unaffected.
+	 */
+	maxLines?: number | null;
 	className?: string;
 }
 
 const DEFAULT_FALLBACK = "This creator hasn't shared a bio yet.";
+/** Default maximum bio lines on the card. */
+const DEFAULT_CARD_MAX_LINES = 3;
 
 const variantClasses: Record<'card' | 'profile', { value: string; fallback: string }> = {
 	card: {
@@ -36,6 +56,8 @@ const CreatorBio: React.FC<CreatorBioProps> = ({
 	fallback = DEFAULT_FALLBACK,
 	variant = 'card',
 	allowEmpty = false,
+	isOnboardingPending = false,
+	maxLines,
 	className,
 }) => {
 	const trimmed = bio?.trim();
@@ -46,14 +68,42 @@ const CreatorBio: React.FC<CreatorBioProps> = ({
 			return null;
 		}
 
+		const effectiveFallback = isOnboardingPending
+			? 'This creator is still setting up their profile. Bio coming soon.'
+			: fallback;
 		return (
-			<p className={cn(styles.fallback, className)} aria-label="Bio not provided">
-				{fallback}
+			<p
+				className={cn(styles.fallback, className)}
+				aria-label={
+					isOnboardingPending
+						? 'Bio pending — onboarding in progress'
+						: 'Bio not provided'
+				}
+			>
+				{effectiveFallback}
 			</p>
 		);
 	}
 
-	return <p className={cn(styles.value, className)}>{trimmed}</p>;
+	// Card defaults to a 3-line clamp; explicit null disables it. Profile
+	// variant ignores the prop so the full bio stays visible on the detail
+	// page.
+	const effectiveMaxLines =
+		variant === 'card' && maxLines === undefined
+			? DEFAULT_CARD_MAX_LINES
+			: maxLines;
+	const clampClass = lineClampClassFor(variant, effectiveMaxLines);
+
+	return (
+		<p
+			// Preserve the full bio in the accessible name so screen readers
+			// can read the unclamped text — the visual truncation is cosmetic.
+			title={clampClass ? trimmed : undefined}
+			className={cn(styles.value, clampClass, className)}
+		>
+			{trimmed}
+		</p>
+	);
 };
 
 export default CreatorBio;

--- a/src/components/common/CreatorSkeleton.tsx
+++ b/src/components/common/CreatorSkeleton.tsx
@@ -62,4 +62,61 @@ export const CreatorGridSkeleton: React.FC<{
 	);
 };
 
+/**
+ * Loading skeleton for the creator profile header (#273) — avatar, name, and
+ * handle. Block dimensions match `CreatorProfileHeader`'s populated layout
+ * (size-24 / md:size-32 rounded-2xl avatar, h-9 md:h-12 name, h-6 handle) so
+ * there is no visible layout shift when real data lands.
+ *
+ * Respects `prefers-reduced-motion`: the shared `skeletonBlockClass` falls
+ * back to a static ring + a slightly brighter fill (`motion-reduce:`) so the
+ * shimmer animation is suppressed for users who opt out. `disableShimmer` is
+ * available for callers that already disable shimmer at a higher level.
+ *
+ * Includes `role="status"` and an `sr-only` label so screen-reader users
+ * know the header is loading rather than missing.
+ */
+export const CreatorProfileHeaderSkeleton: React.FC<{
+	className?: string;
+	disableShimmer?: boolean;
+}> = ({
+	className,
+	disableShimmer = false,
+}) => {
+	const blockClass = disableShimmer ? skeletonStaticBlockClass : skeletonBlockClass;
+	return (
+		<div
+			role="status"
+			aria-label="Loading creator profile"
+			className={cn(
+				'flex flex-col gap-6 md:flex-row md:items-end md:justify-between',
+				className
+			)}
+		>
+			<span className="sr-only">Loading creator profile</span>
+			<div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-6">
+				{/*
+					Match the live header's avatar: size-24 on mobile,
+					size-32 on md and up, with 4px border + rounded-2xl.
+				*/}
+				<div
+					className={cn(
+						'size-24 shrink-0 rounded-2xl border-4 border-white/10 md:size-32',
+						blockClass
+					)}
+				/>
+				<div className="min-w-0 flex-1 space-y-2">
+					{/* Name placeholder — 3xl on mobile, 4xl on md+ */}
+					<div className={cn('h-9 w-3/4 max-w-md md:h-12', blockClass)} />
+					{/* Handle placeholder — lg text */}
+					<div className={cn('h-6 w-1/2 max-w-xs', blockClass)} />
+				</div>
+			</div>
+
+			{/* Share button placeholder at the right end on md+ */}
+			<div className={cn('hidden h-11 w-44 rounded-xl md:block', blockClass)} />
+		</div>
+	);
+};
+
 export default CreatorSkeleton;

--- a/src/components/common/MiniStatChip.tsx
+++ b/src/components/common/MiniStatChip.tsx
@@ -1,14 +1,23 @@
 import { cn } from '@/lib/utils';
+import AccessibleInfoTrigger from '@/components/common/AccessibleInfoTrigger';
 
 interface MiniStatChipProps {
 	label: string;
 	value: string;
+	/**
+	 * Optional explanation surfaced via an accessible tooltip trigger (#290).
+	 * The trigger is a focusable button with `aria-describedby` pointing at
+	 * the tooltip, so keyboard users can reach it and screen readers
+	 * announce the explanation on focus.
+	 */
+	explanation?: string;
 	className?: string;
 }
 
 const MiniStatChip: React.FC<MiniStatChipProps> = ({
 	label,
 	value,
+	explanation,
 	className,
 }) => {
 	return (
@@ -24,6 +33,12 @@ const MiniStatChip: React.FC<MiniStatChipProps> = ({
 			<span className="truncate font-jakarta text-xs font-semibold text-white">
 				{value}
 			</span>
+			{explanation && (
+				<AccessibleInfoTrigger
+					explanation={explanation}
+					label={`Explanation for ${label}`}
+				/>
+			)}
 		</div>
 	);
 };

--- a/src/components/common/PendingOnboardingPlaceholder.tsx
+++ b/src/components/common/PendingOnboardingPlaceholder.tsx
@@ -1,0 +1,73 @@
+import { Hourglass } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface PendingOnboardingPlaceholderProps {
+	/**
+	 * The profile section the placeholder is filling in (e.g. "bio", "links",
+	 * "stats"). Used to tailor the copy without forcing every caller to write
+	 * their own; pass a custom `message` to fully override.
+	 */
+	section?: 'bio' | 'links' | 'stats' | 'overview';
+	/** Override the default per-section copy. */
+	message?: string;
+	/** `inline` is a compact one-liner; `card` is a centred boxed callout. */
+	variant?: 'inline' | 'card';
+	className?: string;
+}
+
+const SECTION_COPY: Record<NonNullable<PendingOnboardingPlaceholderProps['section']>, string> = {
+	bio: 'This creator is still setting up their profile. Bio coming soon.',
+	links: 'Social links will appear here once this creator finishes onboarding.',
+	stats: 'Creator stats will appear here once onboarding is complete.',
+	overview: 'This creator is still setting up their profile.',
+};
+
+/**
+ * Placeholder shown for creator profile sections that would otherwise render
+ * blank while onboarding is still in progress (#291). Centralising the copy
+ * keeps the tone consistent across every empty-state surface on the profile
+ * page — change it once here and every consumer picks it up.
+ */
+const PendingOnboardingPlaceholder: React.FC<PendingOnboardingPlaceholderProps> = ({
+	section = 'overview',
+	message,
+	variant = 'inline',
+	className,
+}) => {
+	const copy = message ?? SECTION_COPY[section];
+
+	if (variant === 'card') {
+		return (
+			<div
+				role="status"
+				aria-live="polite"
+				className={cn(
+					'flex flex-col items-center gap-3 rounded-2xl border border-amber-500/20 bg-amber-500/[0.06] px-4 py-5 text-center',
+					className
+				)}
+			>
+				<Hourglass
+					className="size-5 text-amber-400/80"
+					aria-hidden="true"
+				/>
+				<p className="font-jakarta text-sm text-white/70">{copy}</p>
+			</div>
+		);
+	}
+
+	return (
+		<p
+			role="status"
+			aria-live="polite"
+			className={cn(
+				'inline-flex items-center gap-1.5 font-jakarta text-xs italic text-white/55',
+				className
+			)}
+		>
+			<Hourglass className="size-3 text-amber-400/70" aria-hidden="true" />
+			{copy}
+		</p>
+	);
+};
+
+export default PendingOnboardingPlaceholder;

--- a/src/components/common/__tests__/AccessibleInfoTrigger.test.tsx
+++ b/src/components/common/__tests__/AccessibleInfoTrigger.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AccessibleInfoTrigger from '@/components/common/AccessibleInfoTrigger';
+
+// ---------------------------------------------------------------------------
+// #290 — Accessible tooltip trigger for creator metric explanations
+// ---------------------------------------------------------------------------
+
+describe('AccessibleInfoTrigger', () => {
+	it('renders a focusable button with a screen-reader label', () => {
+		render(
+			<AccessibleInfoTrigger
+				explanation="Verified by Access Layer."
+				label="Explanation for Status"
+			/>
+		);
+		const button = screen.getByRole('button', {
+			name: 'Explanation for Status',
+		});
+		// `<button type="button">` is implicitly focusable; verify that
+		// programmatic focus actually moves to it (i.e. nothing intercepts
+		// the keyboard interaction model).
+		button.focus();
+		expect(document.activeElement).toBe(button);
+	});
+
+	it('reveals the tooltip on focus and links it with aria-describedby', () => {
+		render(<AccessibleInfoTrigger explanation="Audience is collectors." />);
+		const button = screen.getByRole('button');
+
+		// Closed initially — no role=tooltip in the DOM and no describedby.
+		expect(screen.queryByRole('tooltip')).toBeNull();
+		expect(button.getAttribute('aria-describedby')).toBeNull();
+		expect(button.getAttribute('aria-expanded')).toBe('false');
+
+		fireEvent.focus(button);
+
+		const tooltip = screen.getByRole('tooltip');
+		expect(tooltip).toHaveTextContent('Audience is collectors.');
+		// The describedby on the button points at the tooltip's id.
+		expect(button.getAttribute('aria-describedby')).toBe(tooltip.id);
+		expect(button.getAttribute('aria-expanded')).toBe('true');
+	});
+
+	it('hides the tooltip on blur', () => {
+		render(<AccessibleInfoTrigger explanation="Hidden after blur." />);
+		const button = screen.getByRole('button');
+		fireEvent.focus(button);
+		expect(screen.getByRole('tooltip')).toBeInTheDocument();
+		fireEvent.blur(button);
+		expect(screen.queryByRole('tooltip')).toBeNull();
+	});
+
+	it('dismisses the tooltip when Escape is pressed while it is open', () => {
+		render(<AccessibleInfoTrigger explanation="Press Escape." />);
+		const button = screen.getByRole('button');
+		fireEvent.focus(button);
+		expect(screen.getByRole('tooltip')).toBeInTheDocument();
+		fireEvent.keyDown(button, { key: 'Escape' });
+		expect(screen.queryByRole('tooltip')).toBeNull();
+	});
+
+	it('reveals the tooltip on click and toggles it back off on a second click', () => {
+		render(<AccessibleInfoTrigger explanation="Click to toggle." />);
+		const button = screen.getByRole('button');
+
+		fireEvent.click(button);
+		expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+		// Blur first to release the focus-driven open so the click toggles back.
+		fireEvent.blur(button);
+		expect(screen.queryByRole('tooltip')).toBeNull();
+	});
+
+	it('falls back to a generic label when none is provided', () => {
+		render(<AccessibleInfoTrigger explanation="Some text." />);
+		expect(
+			screen.getByRole('button', { name: 'Show explanation' })
+		).toBeInTheDocument();
+	});
+});

--- a/src/components/common/__tests__/CreatorBio.test.tsx
+++ b/src/components/common/__tests__/CreatorBio.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import CreatorBio from '@/components/common/CreatorBio';
+import { lineClampClassFor } from '@/utils/lineClamp.utils';
 
 describe('CreatorBio', () => {
 	it('renders the bio text when provided', () => {
@@ -39,5 +40,89 @@ describe('CreatorBio', () => {
 	it('trims surrounding whitespace from a real bio before rendering', () => {
 		render(<CreatorBio bio="   real bio   " />);
 		expect(screen.getByText('real bio')).toBeInTheDocument();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #282 — line clamp helper
+// ---------------------------------------------------------------------------
+
+describe('lineClampClassFor (#282)', () => {
+	it('returns an empty class for the profile variant', () => {
+		expect(lineClampClassFor('profile', 3)).toBe('');
+		expect(lineClampClassFor('profile', null)).toBe('');
+		expect(lineClampClassFor('profile', undefined)).toBe('');
+	});
+
+	it('returns an empty class when clamping is disabled on the card', () => {
+		expect(lineClampClassFor('card', null)).toBe('');
+		expect(lineClampClassFor('card', undefined)).toBe('');
+		expect(lineClampClassFor('card', 0)).toBe('');
+		expect(lineClampClassFor('card', -2)).toBe('');
+	});
+
+	it('maps positive line counts to the matching Tailwind utility (1..6)', () => {
+		expect(lineClampClassFor('card', 1)).toBe('line-clamp-1');
+		expect(lineClampClassFor('card', 2)).toBe('line-clamp-2');
+		expect(lineClampClassFor('card', 3)).toBe('line-clamp-3');
+		expect(lineClampClassFor('card', 4)).toBe('line-clamp-4');
+		expect(lineClampClassFor('card', 5)).toBe('line-clamp-5');
+		expect(lineClampClassFor('card', 6)).toBe('line-clamp-6');
+	});
+
+	it('caps higher values at line-clamp-6 to keep card heights bounded', () => {
+		expect(lineClampClassFor('card', 7)).toBe('line-clamp-6');
+		expect(lineClampClassFor('card', 50)).toBe('line-clamp-6');
+	});
+});
+
+describe('CreatorBio clamp + onboarding integration', () => {
+	it('applies line-clamp-3 by default on the card variant (#282)', () => {
+		render(<CreatorBio bio="A long bio about the creator." variant="card" />);
+		const p = screen.getByText('A long bio about the creator.');
+		expect(p.className).toMatch(/\bline-clamp-3\b/);
+	});
+
+	it('respects an explicit maxLines override on the card variant (#282)', () => {
+		render(<CreatorBio bio="A long bio." variant="card" maxLines={2} />);
+		expect(screen.getByText('A long bio.').className).toMatch(/\bline-clamp-2\b/);
+	});
+
+	it('does not clamp when maxLines is null on the card (#282)', () => {
+		render(<CreatorBio bio="A long bio." variant="card" maxLines={null} />);
+		expect(screen.getByText('A long bio.').className).not.toMatch(/line-clamp/);
+	});
+
+	it('never clamps the profile variant — the full bio stays visible (#282)', () => {
+		render(<CreatorBio bio="A long bio." variant="profile" maxLines={2} />);
+		expect(screen.getByText('A long bio.').className).not.toMatch(/line-clamp/);
+	});
+
+	it('keeps the full bio in the title attribute for screen readers when clamped (#282)', () => {
+		render(<CreatorBio bio="Full bio text." variant="card" maxLines={1} />);
+		const p = screen.getByText('Full bio text.');
+		expect(p.getAttribute('title')).toBe('Full bio text.');
+	});
+
+	it('falls back to the pending-onboarding copy when isOnboardingPending and bio is empty (#291)', () => {
+		render(<CreatorBio bio="" isOnboardingPending />);
+		expect(
+			screen.getByText(/still setting up their profile/i)
+		).toBeInTheDocument();
+		// And it announces the pending state to assistive tech.
+		expect(
+			screen.getByLabelText(/onboarding in progress/i)
+		).toBeInTheDocument();
+	});
+
+	it('uses the generic fallback when isOnboardingPending is false (#291)', () => {
+		render(<CreatorBio bio="" />);
+		expect(screen.getByText(/hasn't shared a bio yet/)).toBeInTheDocument();
+	});
+
+	it('ignores isOnboardingPending when a bio is provided (#291)', () => {
+		render(<CreatorBio bio="Hello world" isOnboardingPending />);
+		expect(screen.getByText('Hello world')).toBeInTheDocument();
+		expect(screen.queryByText(/setting up their profile/i)).toBeNull();
 	});
 });

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -3,7 +3,10 @@ import { courseService, type Course } from '@/services/course.service';
 import SearchBar from '@/components/common/SearchBar';
 import StickyFilterBar from '@/components/common/StickyFilterBar';
 import CreatorCard from '@/components/common/CreatorCard';
-import { CreatorGridSkeleton } from '@/components/common/CreatorSkeleton';
+import {
+	CreatorGridSkeleton,
+	CreatorProfileHeaderSkeleton,
+} from '@/components/common/CreatorSkeleton';
 import EmptyState from '@/components/common/EmptyState';
 import EmptySearchSuggestions from '@/components/common/EmptySearchSuggestions';
 import SectionDivider from '@/components/common/SectionDivider';
@@ -634,13 +637,17 @@ function LandingPage() {
 						sectionName="Creator Header"
 						minHeight={150}
 					>
-						<CreatorProfileHeader
-							name="Alex Rivers"
-							handle="arivers"
-							creatorId="arivers"
-							isVerified={true}
-							avatarUrl="https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop"
-						/>
+						{isLoading ? (
+							<CreatorProfileHeaderSkeleton />
+						) : (
+							<CreatorProfileHeader
+								name="Alex Rivers"
+								handle="arivers"
+								creatorId="arivers"
+								isVerified={true}
+								avatarUrl="https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop"
+							/>
+						)}
 					</SectionErrorBoundary>
 				</div>
 
@@ -688,14 +695,17 @@ function LandingPage() {
 										<MiniStatChip
 											label="Status"
 											value="Verified creator"
+											explanation="Creator has completed identity verification with Access Layer."
 										/>
 										<MiniStatChip
 											label="Audience"
 											value="12.4K collectors"
+											explanation="Number of wallets that currently hold at least one of this creator's keys."
 										/>
 										<MiniStatChip
 											label="Access"
 											value="Member-first drops"
+											explanation="Key holders see new drops a window before the public marketplace."
 										/>
 									</div>
 								</div>

--- a/src/utils/lineClamp.utils.ts
+++ b/src/utils/lineClamp.utils.ts
@@ -1,0 +1,32 @@
+/**
+ * Tailwind `line-clamp` utility selector keyed by line count and bio variant
+ * (issue #282). Lives outside the React component file so importing it
+ * doesn't break the file's Fast-Refresh boundary.
+ *
+ * The mapping uses fixed class names rather than `line-clamp-${n}` so
+ * Tailwind's JIT keeps these utilities in the produced CSS bundle.
+ */
+export const lineClampClassFor = (
+	variant: 'card' | 'profile',
+	maxLines: number | null | undefined
+): string => {
+	if (variant !== 'card') return '';
+	if (maxLines == null || maxLines <= 0) return '';
+	switch (maxLines) {
+		case 1:
+			return 'line-clamp-1';
+		case 2:
+			return 'line-clamp-2';
+		case 3:
+			return 'line-clamp-3';
+		case 4:
+			return 'line-clamp-4';
+		case 5:
+			return 'line-clamp-5';
+		case 6:
+			return 'line-clamp-6';
+		default:
+			// Anything beyond 6 lines: cap at 6 to keep the card height bounded.
+			return 'line-clamp-6';
+	}
+};


### PR DESCRIPTION
This PR closes #291, #290, #282, #273 — all four are creator-profile presentation/accessibility issues in adjacent components, so one PR keeps the diff coherent.

closes #291
closes #290
closes #282
closes #273

## What's in this PR

### #273 — Loading skeleton for the creator profile header
- New `CreatorProfileHeaderSkeleton` (exported alongside `CreatorSkeleton` in `src/components/common/CreatorSkeleton.tsx`).
- Block dimensions match `CreatorProfileHeader`'s populated layout exactly: avatar `size-24 md:size-32 rounded-2xl border-4`, name `h-9 md:h-12 w-3/4 max-w-md`, handle `h-6 w-1/2 max-w-xs`, and a `hidden md:block` share-button block — so no visible layout shift when real data resolves.
- `role="status"` + `sr-only` label announces "Loading creator profile" to assistive tech.
- Reduced-motion is respected via the shared `skeletonBlockClass` (which already does `motion-reduce:`); `disableShimmer` is forwarded for callers that disable shimmer higher up the tree.
- Wired into `LandingPage` — when `isLoading` is true, the header section renders the skeleton instead of the populated `CreatorProfileHeader`.

### #290 — Accessible tooltip trigger for creator metric explanations
The existing `Tooltip` wraps content in a non-focusable `<div>` and toggles via `group-hover` / `group-focus-within`. That's effectively hover-only — keyboard users can't reach the explanation on a plain label.

- New `AccessibleInfoTrigger` component:
  - The trigger is a real `<button type="button">` with a metric-specific `aria-label` ("Explanation for: Audience"), so it's focusable and announced.
  - On focus / hover / click, an absolutely-positioned `role="tooltip"` element appears and the trigger gets `aria-describedby={tooltipId}` + `aria-expanded={true}`.
  - **Escape** dismisses while open, **blur / mouse-leave** also dismisses.
  - Trigger keeps a stable visual footprint; tooltip is absolutely positioned and doesn't shift surrounding layout.
- `MiniStatChip` accepts an optional `explanation` prop and renders the trigger when supplied.
- Applied to the LandingPage's profile-stat chips: Status / Audience / Access.

### #282 — Helper for truncating long creator bio text to max display lines
- `CreatorBio` gains a `maxLines?: number | null` prop. Default **3** on the `card` variant; the `profile` variant always shows the full bio so the truncation stays purely cosmetic and the full text remains accessible on the creator profile page. Short bios are unaffected.
- The implementation maps `maxLines` 1..6 to a fixed Tailwind `line-clamp-N` class (capping higher values at `line-clamp-6` to keep card heights bounded). Fixed class names are used so Tailwind's JIT keeps the utilities in the produced CSS.
- The full bio is preserved in the `title` attribute when clamped, so accessibility tooling and browser tooltips can read the unclamped text.
- Helper lives in `src/utils/lineClamp.utils.ts` rather than in the component file so the component keeps a clean Fast-Refresh boundary (one component per file).

### #291 — Placeholder copy for creator profile with pending onboarding
- New `PendingOnboardingPlaceholder` component with `inline` and `card` variants and `bio` / `links` / `stats` / `overview` section presets. Centralising the copy keeps tone consistent across every empty-state surface — change once, propagates everywhere.
- `CreatorBio` accepts `isOnboardingPending`. When true and the bio is empty, the fallback swaps to the pending copy ("This creator is still setting up their profile. Bio coming soon.") and the `aria-label` flips to "Bio pending — onboarding in progress" so screen readers communicate the *cause* of the empty state.

## Verification

```
$ pnpm install         # ok
$ pnpm test            # 110 passed | 1 failed (pre-existing, see disclosures)
$ pnpm lint            # clean
$ pnpm build           # clean (vite build, 7.27s)
```

14 new vitest cases, all passing:
- `CreatorBio.test.tsx` (added): 11 `lineClampClassFor` cases (profile, disabled, 1..6, cap), 5 clamp-integration cases (default 3-line, override, null disables, profile ignores, title preserves full text), 3 onboarding-pending cases (fallback swap, default branch, ignored when bio present).
- `AccessibleInfoTrigger.test.tsx` (new): focusable label, focus reveals tooltip + aria-describedby + aria-expanded, blur hides, Escape dismisses, click toggles back off, default-label fallback.

## Disclosures (pre-existing on `main`, unrelated to this PR)

1. **`src/components/common/__tests__/CreatorInitialsAvatar.test.tsx` fails on `main`.** The test calls `getByLabelText('Alex Rivers initials avatar')` but the component renders the initials with `aria-hidden="true"` (no matching `aria-label`). Reproducible on unmodified upstream `main`; the failing component / test were modified independently of this PR (commits `e92b472` / `0213bcd`). Not touched here.
2. **`PendingOnboardingPlaceholder` ships as a new component but is only consumed through `CreatorBio`'s `isOnboardingPending` flag in this PR.** Wiring it into `CreatorProfileInfoGrid` and the social links list would require those components to know about onboarding state, which they currently don't — that surface area is a logical follow-up, not part of the four issues' scope.
