### PR TITLE
Issue 368

### DIFF
--- a/src/components/common/CreatorBreadcrumb.tsx
+++ b/src/components/common/CreatorBreadcrumb.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import { ChevronRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { normalizeCreatorDisplayName } from '@/utils/creatorDisplayName.utils';
 
 interface CreatorBreadcrumbProps {
 	parentLabel: string;
@@ -16,6 +17,9 @@ const CreatorBreadcrumb: React.FC<CreatorBreadcrumbProps> = ({
 	currentLabel,
 	className,
 }) => {
+	const displayCurrentLabel =
+		normalizeCreatorDisplayName(currentLabel) || 'Unnamed creator';
+
 	return (
 		<nav
 			aria-label="Breadcrumb"
@@ -32,7 +36,7 @@ const CreatorBreadcrumb: React.FC<CreatorBreadcrumbProps> = ({
 			</Link>
 			<ChevronRight className="size-4 text-white/30" />
 			<span className="font-bold text-white truncate max-w-[150px] sm:max-w-none">
-				{currentLabel}
+				{displayCurrentLabel}
 			</span>
 		</nav>
 	);

--- a/src/components/common/CreatorCard.tsx
+++ b/src/components/common/CreatorCard.tsx
@@ -2,7 +2,15 @@ import { useRef, useState } from 'react';
 import { useAccount } from 'wagmi';
 import type { Course } from '@/services/course.service';
 import { cn } from '@/lib/utils';
-import { ShoppingCart, Link as LinkIcon, TrendingUp, MoreVertical, Copy, Share2, ExternalLink } from 'lucide-react';
+import {
+	ShoppingCart,
+	Link as LinkIcon,
+	TrendingUp,
+	MoreVertical,
+	Copy,
+	Share2,
+	ExternalLink,
+} from 'lucide-react';
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -17,6 +25,8 @@ import showToast from '@/utils/toast.util';
 import { formatCompactNumber } from '@/utils/numberFormat.utils';
 import { formatCreatorKeyPriceDisplay } from '@/utils/keyPriceDisplay.utils';
 import { formatCreatorHandle } from '@/utils/handleDisplay.utils';
+import { normalizeCreatorDisplayName } from '@/utils/creatorDisplayName.utils';
+import { getCreatorPriceChartAccessibilityCopy } from '@/utils/creatorPriceChartAccessibility.utils';
 import { formatJoinDate } from '@/utils/formatJoinDate';
 import { useSystemTheme } from '@/utils/useSystemTheme';
 import { Tooltip } from '@/components/ui/tooltip';
@@ -68,22 +78,36 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
 	const displayInstructorHandle =
 		formatCreatorHandle(creator.instructorId) || '@creator';
 	const displaySocialHandle = formatCreatorHandle(creator.socialHandle);
+	const displayCreatorName =
+		normalizeCreatorDisplayName(creator.title) || 'Unnamed creator';
+	const priceChartAccessibility = getCreatorPriceChartAccessibilityCopy({
+		name: displayCreatorName,
+		price: creator.price,
+		priceStroops: creator.priceStroops,
+		change24h: creator.change24h,
+	});
+	const priceChartDescriptionId = `creator-price-chart-description-${creator.id}`;
 	const { isConnected } = useAccount();
-	const { isMismatch: isNetworkMismatch, expectedChainName } = useNetworkMismatch();
+	const { isMismatch: isNetworkMismatch, expectedChainName } =
+		useNetworkMismatch();
 	const [transactionState, setTransactionState] = useState<
 		'idle' | 'submitting' | 'failed' | 'success'
 	>('idle');
 	const [failureDrawerOpen, setFailureDrawerOpen] = useState(false);
-	const [failureDetails, setFailureDetails] = useState<TransactionFailureDetails>({
-		errorMessage: '',
-	});
+	const [failureDetails, setFailureDetails] =
+		useState<TransactionFailureDetails>({
+			errorMessage: '',
+		});
 	const hasFailedOnceRef = useRef(false);
 	const trackTransactionEvent = useTransactionTelemetry();
 
 	const runPurchaseAttempt = () => {
 		setTransactionState('submitting');
-		trackTransactionEvent('tx_submitted', { creatorId: creator.id, creatorTitle: creator.title });
-		showToast.loading(`Purchasing keys for ${creator.title}...`);
+		trackTransactionEvent('tx_submitted', {
+			creatorId: creator.id,
+			creatorTitle: displayCreatorName,
+		});
+		showToast.loading(`Purchasing keys for ${displayCreatorName}...`);
 
 		window.setTimeout(() => {
 			toast.remove();
@@ -92,7 +116,8 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
 				hasFailedOnceRef.current = true;
 				setTransactionState('failed');
 				setFailureDetails({
-					errorMessage: 'Transaction failed: Insufficient balance to complete the purchase.',
+					errorMessage:
+						'Transaction failed: Insufficient balance to complete the purchase.',
 					errorCode: 'ERR_INSUFFICIENT_BALANCE',
 					txHash: '0xabcd1234...failed',
 					developerDetails: {
@@ -108,10 +133,13 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
 
 			hasFailedOnceRef.current = false;
 			setTransactionState('success');
-			trackTransactionEvent('tx_confirmed', { creatorId: creator.id, creatorTitle: creator.title });
+			trackTransactionEvent('tx_confirmed', {
+				creatorId: creator.id,
+				creatorTitle: displayCreatorName,
+			});
 			showToast.transactionSuccess(
 				'Purchase Successful!',
-				`You successfully bought a key for ${creator.title}`,
+				`You successfully bought a key for ${displayCreatorName}`,
 				'0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
 				'https://stellar.expert/explorer/testnet/tx/0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'
 			);
@@ -136,7 +164,7 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
 	const handleShare = () => {
 		const url = `${window.location.origin}/creator/${creator.id}`;
 		if (navigator.share) {
-			navigator.share({ title: creator.title, url }).catch(() => {});
+			navigator.share({ title: displayCreatorName, url }).catch(() => {});
 		} else {
 			navigator.clipboard
 				.writeText(url)
@@ -160,7 +188,7 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
 			return;
 		}
 
-		toast.success(`Purchasing keys for ${creator.title}...`, {
+		toast.success(`Purchasing keys for ${displayCreatorName}...`, {
 			duration: 3000,
 		});
 		// Implementation for contract interaction would go here
@@ -177,7 +205,7 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
 			<div className="absolute right-3 top-3 z-20">
 				<DropdownMenu>
 					<DropdownMenuTrigger
-						aria-label={`More actions for ${creator.title}`}
+						aria-label={`More actions for ${displayCreatorName}`}
 						className="flex size-8 items-center justify-center rounded-full text-white/40 transition-colors hover:bg-white/10 hover:text-white/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/60"
 					>
 						<MoreVertical className="size-4" aria-hidden="true" />
@@ -187,7 +215,7 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
 						className="w-48 border-white/10 bg-slate-900/95 backdrop-blur-xl"
 					>
 						<DropdownMenuLabel className="text-xs text-white/50">
-							{creator.title}
+							{displayCreatorName}
 						</DropdownMenuLabel>
 						<DropdownMenuSeparator className="bg-white/10" />
 						<DropdownMenuItem
@@ -223,10 +251,13 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
 				aria-labelledby={`creator-name-${creator.id}`}
 			>
 				<CreatorInitialsAvatar
-					name={creator.title}
+					name={displayCreatorName}
 					creatorId={creator.id}
 					imageSrc={creator.thumbnail}
-					imageClassName={cn("transition-transform duration-500 motion-reduce:transition-none motion-safe:md:group-hover:scale-[1.03] motion-reduce:md:group-hover:scale-100", isDarkMode ? 'bg-gray-800' : 'bg-gray-100')}
+					imageClassName={cn(
+						'transition-transform duration-500 motion-reduce:transition-none motion-safe:md:group-hover:scale-[1.03] motion-reduce:md:group-hover:scale-100',
+						isDarkMode ? 'bg-gray-800' : 'bg-gray-100'
+					)}
 				/>
 				<div className="absolute inset-0 bg-gradient-to-t from-slate-950/80 via-transparent to-transparent opacity-0 transition-opacity duration-300 motion-reduce:transition-none motion-safe:md:group-hover:opacity-100 motion-reduce:md:group-hover:opacity-100" />
 				{creator.volume24h !== undefined && (
@@ -251,7 +282,7 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
 						id={`creator-name-${creator.id}`}
 						className="font-jakarta text-lg font-bold text-white"
 					>
-						{creator.title}
+						{displayCreatorName}
 					</h3>
 					<VerifiedBadge
 						verified={Boolean(creator.isVerified)}
@@ -273,7 +304,11 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
 					</CreatorHandleHoverCard>
 				</p>
 
-				<CreatorBio bio={creator.description} variant="card" className="mt-2" />
+				<CreatorBio
+					bio={creator.description}
+					variant="card"
+					className="mt-2"
+				/>
 
 				{creator.nextDropAt ? (
 					<CreatorDropCountdown nextDropAt={creator.nextDropAt} />
@@ -306,7 +341,29 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
 
 				{/*  Sparkline placeholder */}
 				<div className="mt-3">
-					<div className="h-10 w-full rounded-lg bg-white/10 animate-pulse" />
+					<div
+						role="img"
+						aria-label={priceChartAccessibility.summary}
+						aria-describedby={priceChartDescriptionId}
+						className="h-10 w-full rounded-lg bg-white/10 animate-pulse"
+					/>
+					<table id={priceChartDescriptionId} className="sr-only">
+						<caption>{priceChartAccessibility.summary}</caption>
+						<thead>
+							<tr>
+								<th scope="col">Point</th>
+								<th scope="col">Key price</th>
+							</tr>
+						</thead>
+						<tbody>
+							{priceChartAccessibility.points.map(point => (
+								<tr key={point.label}>
+									<th scope="row">{point.label}</th>
+									<td>{point.value}</td>
+								</tr>
+							))}
+						</tbody>
+					</table>
 				</div>
 
 				<div className="mt-3 flex flex-wrap gap-2">
@@ -323,7 +380,20 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
 						<CardMetaRow
 							label="Join Date"
 							value={
-								<Tooltip content={<p>{new Date(creator.joinedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</p>}>
+								<Tooltip
+									content={
+										<p>
+											{new Date(creator.joinedAt).toLocaleDateString(
+												'en-US',
+												{
+													year: 'numeric',
+													month: 'long',
+													day: 'numeric',
+												}
+											)}
+										</p>
+									}
+								>
 									<span className="text-white/75 cursor-default truncate">
 										{formatJoinDate(creator.joinedAt)}
 									</span>
@@ -344,9 +414,7 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
 								: 'No public handle'
 						}
 						valueTitle={
-							creator.socialHandle
-								? displaySocialHandle
-								: undefined
+							creator.socialHandle ? displaySocialHandle : undefined
 						}
 						valueClassName={
 							creator.socialHandle
@@ -406,7 +474,7 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
 					id={`creator-card-actions-label-${creator.id}`}
 					className="sr-only"
 				>
-					Purchase actions for {creator.title}
+					Purchase actions for {displayCreatorName}
 				</span>
 				<NetworkFeeHint className="shrink-0" />
 				<AsyncButton

--- a/src/components/common/CreatorProfileHeader.tsx
+++ b/src/components/common/CreatorProfileHeader.tsx
@@ -9,6 +9,7 @@ import VerifiedBadge from '@/components/common/VerifiedBadge';
 import CreatorInitialsAvatar from '@/components/common/CreatorInitialsAvatar';
 import CreatorBio from '@/components/common/CreatorBio';
 import { formatCreatorHandle } from '@/utils/handleDisplay.utils';
+import { normalizeCreatorDisplayName } from '@/utils/creatorDisplayName.utils';
 import { CREATOR_CARD_MEDIA_RADIUS_CLASS } from '@/utils/creatorCardTokens';
 
 interface CreatorProfileHeaderProps {
@@ -47,6 +48,7 @@ const CreatorProfileHeader: React.FC<CreatorProfileHeaderProps> = ({
 	// Display-normalised handle; raw `handle` is preserved for any equality /
 	// URL construction the caller might do via the prop.
 	const displayHandle = formatCreatorHandle(handle);
+	const displayName = normalizeCreatorDisplayName(name) || 'Unnamed creator';
 
 	const handleShare = async () => {
 		let url = window.location.href;
@@ -57,7 +59,7 @@ const CreatorProfileHeader: React.FC<CreatorProfileHeaderProps> = ({
 		if (navigator.share) {
 			try {
 				await navigator.share({
-					title: `${name} (${displayHandle || `@${handle}`}) on Access Layer`,
+					title: `${displayName} (${displayHandle || `@${handle}`}) on Access Layer`,
 					url,
 				});
 			} catch (err) {
@@ -105,19 +107,27 @@ const CreatorProfileHeader: React.FC<CreatorProfileHeaderProps> = ({
 							CREATOR_CARD_MEDIA_RADIUS_CLASS
 						)}
 					>
-						<CreatorInitialsAvatar name={name} creatorId={creatorId} imageSrc={avatarUrl} />
+						<CreatorInitialsAvatar
+							name={displayName}
+							creatorId={creatorId}
+							imageSrc={avatarUrl}
+						/>
 					</motion.div>
 					<div className="min-w-0 space-y-0.5">
 						<div className="flex items-center gap-2 overflow-hidden">
 							<motion.h1
 								id="creator-profile-name"
-								animate={{ fontSize: isScrolled ? '1.25rem' : '1.875rem' }}
+								animate={{
+									fontSize: isScrolled ? '1.25rem' : '1.875rem',
+								}}
 								className={cn(
-									"truncate font-grotesque font-black tracking-tight text-white transition-all duration-300",
-									isScrolled ? "text-xl md:text-2xl" : "text-3xl md:text-4xl"
+									'truncate font-grotesque font-black tracking-tight text-white transition-all duration-300',
+									isScrolled
+										? 'text-xl md:text-2xl'
+										: 'text-3xl md:text-4xl'
 								)}
 							>
-								{name}
+								{displayName}
 							</motion.h1>
 							{isVerified && (
 								<div className="shrink-0">
@@ -150,16 +160,18 @@ const CreatorProfileHeader: React.FC<CreatorProfileHeaderProps> = ({
 					</div>
 				</div>
 
-				<div className={cn(
-					"flex items-center gap-3 transition-transform duration-300",
-					isScrolled ? "scale-90" : "scale-100"
-				)}>
+				<div
+					className={cn(
+						'flex items-center gap-3 transition-transform duration-300',
+						isScrolled ? 'scale-90' : 'scale-100'
+					)}
+				>
 					<Button
 						onClick={handleShare}
 						variant="outline"
 						className={cn(
-							"rounded-xl border-white/10 bg-white/5 font-bold text-white transition-all hover:border-amber-500/30 hover:bg-amber-500/10 active:scale-95",
-							isScrolled ? "h-9 px-3 text-xs" : "h-11 px-4 text-sm"
+							'rounded-xl border-white/10 bg-white/5 font-bold text-white transition-all hover:border-amber-500/30 hover:bg-amber-500/10 active:scale-95',
+							isScrolled ? 'h-9 px-3 text-xs' : 'h-11 px-4 text-sm'
 						)}
 					>
 						{copied ? (
@@ -170,7 +182,11 @@ const CreatorProfileHeader: React.FC<CreatorProfileHeaderProps> = ({
 							<Copy className="mr-2 size-4 text-amber-500" />
 						)}
 						<span className="hidden sm:inline">
-							{copied ? 'Copied!' : canNativeShare ? 'Share Profile' : 'Copy Profile Link'}
+							{copied
+								? 'Copied!'
+								: canNativeShare
+									? 'Share Profile'
+									: 'Copy Profile Link'}
 						</span>
 						<span className="sm:hidden">
 							{copied ? 'Copied' : canNativeShare ? 'Share' : 'Copy'}

--- a/src/components/common/TradeDialog.tsx
+++ b/src/components/common/TradeDialog.tsx
@@ -16,6 +16,7 @@ import PercentageBadge from '@/components/common/PercentageBadge';
 import NetworkFeeHint from '@/components/common/NetworkFeeHint';
 import { TRADE_FEE_ESTIMATE } from '@/constants/fees';
 import { formatTransactionFeeDisplay } from '@/utils/transactionFee.utils';
+import { normalizeCreatorDisplayName } from '@/utils/creatorDisplayName.utils';
 
 export type TradeSide = 'buy' | 'sell';
 
@@ -59,6 +60,8 @@ const TradeDialog: React.FC<TradeDialogProps> = ({
 		parsedAmount > 0 &&
 		(side !== 'sell' || parsedAmount <= availableHoldings);
 
+	const displayCreatorName =
+		normalizeCreatorDisplayName(creatorName) || 'Unnamed creator';
 	const title = side === 'buy' ? 'Buy keys' : 'Sell keys';
 	const confirmLabel = side === 'buy' ? 'Confirm buy' : 'Confirm sell';
 	const estimatedNetworkFee = formatTransactionFeeDisplay(
@@ -90,8 +93,8 @@ const TradeDialog: React.FC<TradeDialogProps> = ({
 					<DialogTitle>{title}</DialogTitle>
 					<DialogDescription>
 						{side === 'buy'
-							? `Purchase creator keys for ${creatorName}.`
-							: `Sell creator keys for ${creatorName}.`}
+							? `Purchase creator keys for ${displayCreatorName}.`
+							: `Sell creator keys for ${displayCreatorName}.`}
 					</DialogDescription>
 				</DialogHeader>
 

--- a/src/components/common/__tests__/CreatorCard.accessibility.test.tsx
+++ b/src/components/common/__tests__/CreatorCard.accessibility.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import CreatorCard from '@/components/common/CreatorCard';
+import type { Course } from '@/services/course.service';
+
+vi.mock('wagmi', () => ({
+	useAccount: () => ({ isConnected: false }),
+	useConnect: () => ({ connectAsync: vi.fn(), connectors: [] }),
+	useReconnect: () => ({ reconnectAsync: vi.fn(), connectors: [] }),
+}));
+
+vi.mock('@/hooks/useNetworkMismatch', () => ({
+	useNetworkMismatch: () => ({
+		isMismatch: false,
+		expectedChainName: 'Stellar Testnet',
+	}),
+}));
+
+vi.mock('@/hooks/useTransactionTelemetry', () => ({
+	useTransactionTelemetry: () => vi.fn(),
+}));
+
+vi.mock('@/utils/useSystemTheme', () => ({
+	useSystemTheme: () => ({ isDarkMode: true }),
+}));
+
+const creator: Course = {
+	id: 'alex-rivers',
+	title: '  Alex   Rivers  ',
+	description: 'Creates cinematic tutorials.',
+	price: 12,
+	creatorShareSupply: 120,
+	instructorId: 'ARivers',
+	category: 'Design',
+	level: 'BEGINNER',
+	change24h: 50,
+};
+
+describe('CreatorCard accessibility', () => {
+	it('renders normalized creator names and accessible price chart data', () => {
+		render(<CreatorCard creator={creator} />);
+
+		expect(
+			screen.getByRole('heading', { name: 'Alex Rivers' })
+		).toBeInTheDocument();
+		expect(screen.queryByText('  Alex   Rivers  ')).not.toBeInTheDocument();
+
+		const priceChart = screen.getByRole('img', {
+			name: /current key price is 12 XLM, up 50%/i,
+		});
+		expect(priceChart).toBeInTheDocument();
+
+		const priceTable = screen.getByRole('table', {
+			name: /price chart for alex rivers/i,
+		});
+		expect(
+			within(priceTable).getByRole('row', {
+				name: /previous 24-hour key price 8 XLM/i,
+			})
+		).toBeInTheDocument();
+		expect(
+			within(priceTable).getByRole('row', {
+				name: /current key price 12 XLM/i,
+			})
+		).toBeInTheDocument();
+	});
+});

--- a/src/utils/__tests__/creatorDisplayName.utils.test.ts
+++ b/src/utils/__tests__/creatorDisplayName.utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeCreatorDisplayName } from '../creatorDisplayName.utils';
+
+describe('normalizeCreatorDisplayName', () => {
+	it('trims leading and trailing whitespace', () => {
+		expect(normalizeCreatorDisplayName('  Alex Rivers  ')).toBe(
+			'Alex Rivers'
+		);
+	});
+
+	it('collapses internal whitespace runs to single spaces', () => {
+		expect(normalizeCreatorDisplayName('Alex   \t\n  Rivers')).toBe(
+			'Alex Rivers'
+		);
+	});
+
+	it('returns an empty string for blank or nullish input', () => {
+		expect(normalizeCreatorDisplayName('   ')).toBe('');
+		expect(normalizeCreatorDisplayName(null)).toBe('');
+		expect(normalizeCreatorDisplayName(undefined)).toBe('');
+	});
+
+	it('does not modify the stored value passed by the caller', () => {
+		const raw = '  Alex   Rivers  ';
+		normalizeCreatorDisplayName(raw);
+		expect(raw).toBe('  Alex   Rivers  ');
+	});
+});

--- a/src/utils/__tests__/creatorPriceChartAccessibility.utils.test.ts
+++ b/src/utils/__tests__/creatorPriceChartAccessibility.utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { getCreatorPriceChartAccessibilityCopy } from '../creatorPriceChartAccessibility.utils';
+
+describe('getCreatorPriceChartAccessibilityCopy', () => {
+	it('summarizes an upward creator price trend and exposes matching data points', () => {
+		const copy = getCreatorPriceChartAccessibilityCopy({
+			name: 'Alex Rivers',
+			price: 12,
+			change24h: 50,
+		});
+
+		expect(copy.summary).toBe(
+			'Price chart for Alex Rivers: current key price is 12 XLM, up 50% over the last 24 hours from approximately 8 XLM.'
+		);
+		expect(copy.points).toEqual([
+			{ label: 'Previous 24-hour key price', value: '8 XLM' },
+			{ label: 'Current key price', value: '12 XLM' },
+		]);
+	});
+
+	it('handles unavailable trend data while keeping current price available', () => {
+		const copy = getCreatorPriceChartAccessibilityCopy({
+			name: 'Mina Park',
+			priceStroops: 5_000_000,
+		});
+
+		expect(copy.summary).toBe(
+			'Price chart for Mina Park: current key price is 0.5 XLM. 24-hour price trend is unavailable.'
+		);
+		expect(copy.points).toEqual([
+			{ label: 'Current key price', value: '0.5 XLM' },
+		]);
+	});
+});

--- a/src/utils/creatorDisplayName.utils.ts
+++ b/src/utils/creatorDisplayName.utils.ts
@@ -1,0 +1,14 @@
+/**
+ * Display-only normalisation for creator names (issue #368).
+ *
+ * Creator display names can be authored with leading/trailing whitespace or
+ * accidental runs of internal whitespace. Rendering a cleaned value keeps card,
+ * profile, and list surfaces visually consistent without changing the stored
+ * value callers received from the API.
+ */
+export const normalizeCreatorDisplayName = (
+	raw: string | null | undefined
+): string => {
+	if (raw == null) return '';
+	return raw.trim().replace(/\s+/g, ' ');
+};

--- a/src/utils/creatorPriceChartAccessibility.utils.ts
+++ b/src/utils/creatorPriceChartAccessibility.utils.ts
@@ -1,0 +1,100 @@
+import {
+	formatDisplayKeyPrice,
+	resolveCreatorKeyPriceStroops,
+	type CreatorKeyPriceFields,
+} from '@/utils/keyPriceDisplay.utils';
+
+interface CreatorPriceChartAccessibilityInput extends CreatorKeyPriceFields {
+	name: string;
+	change24h?: number | null;
+}
+
+export interface CreatorPriceChartPoint {
+	label: string;
+	value: string;
+}
+
+export interface CreatorPriceChartAccessibilityCopy {
+	summary: string;
+	points: CreatorPriceChartPoint[];
+}
+
+const formatChangePercent = (change24h: number): string => {
+	const absoluteChange = Math.abs(change24h);
+	const formatted = new Intl.NumberFormat('en-US', {
+		maximumFractionDigits: 2,
+		minimumFractionDigits: absoluteChange > 0 && absoluteChange < 1 ? 2 : 0,
+	}).format(absoluteChange);
+
+	return `${formatted}%`;
+};
+
+const getPreviousPriceStroops = (
+	currentPriceStroops: number,
+	change24h: number | null | undefined
+): number | null => {
+	if (change24h == null || !Number.isFinite(change24h)) return null;
+	const changeRatio = 1 + change24h / 100;
+	if (changeRatio <= 0) return null;
+	return Math.round(currentPriceStroops / changeRatio);
+};
+
+/**
+ * Builds screen-reader copy and hidden tabular data from the same creator price
+ * fields used by the visual chart so accessible text stays in sync.
+ */
+export const getCreatorPriceChartAccessibilityCopy = ({
+	name,
+	change24h,
+	...priceFields
+}: CreatorPriceChartAccessibilityInput): CreatorPriceChartAccessibilityCopy => {
+	const currentPriceStroops = resolveCreatorKeyPriceStroops(priceFields);
+
+	if (currentPriceStroops == null) {
+		return {
+			summary: `Price chart for ${name}: current key price is unavailable.`,
+			points: [{ label: 'Current key price', value: 'Unavailable' }],
+		};
+	}
+
+	const currentPrice = formatDisplayKeyPrice(currentPriceStroops);
+	const previousPriceStroops = getPreviousPriceStroops(
+		currentPriceStroops,
+		change24h
+	);
+	const points: CreatorPriceChartPoint[] = [];
+
+	if (previousPriceStroops != null) {
+		points.push({
+			label: 'Previous 24-hour key price',
+			value: formatDisplayKeyPrice(previousPriceStroops),
+		});
+	}
+
+	points.push({ label: 'Current key price', value: currentPrice });
+
+	if (change24h == null || !Number.isFinite(change24h)) {
+		return {
+			summary: `Price chart for ${name}: current key price is ${currentPrice}. 24-hour price trend is unavailable.`,
+			points,
+		};
+	}
+
+	if (change24h === 0) {
+		return {
+			summary: `Price chart for ${name}: current key price is ${currentPrice}, unchanged over the last 24 hours.`,
+			points,
+		};
+	}
+
+	const direction = change24h > 0 ? 'up' : 'down';
+	const previousPriceCopy =
+		previousPriceStroops != null
+			? ` from approximately ${formatDisplayKeyPrice(previousPriceStroops)}`
+			: '';
+
+	return {
+		summary: `Price chart for ${name}: current key price is ${currentPrice}, ${direction} ${formatChangePercent(change24h)} over the last 24 hours${previousPriceCopy}.`,
+		points,
+	};
+};


### PR DESCRIPTION
## Summary
Description
Add a display-only normaliser normalizeCreatorDisplayName that trims and collapses internal whitespace without mutating stored values (src/utils/creatorDisplayName.utils.ts).
Add getCreatorPriceChartAccessibilityCopy to derive a screen-reader summary and hidden data points from the same price inputs used by the chart (src/utils/creatorPriceChartAccessibility.utils.ts).
Wire the display-name normaliser into card/profile/trade/breadcrumb surfaces (CreatorCard, CreatorProfileHeader, TradeDialog, CreatorBreadcrumb) so UI copy and share titles use the cleaned name while source values remain unchanged.
Render accessible chart markup in the creator card by adding an role="img" with an aria-label driven by the accessibility helper and an sr-only HTML table containing the chart points so non-visual users can access the underlying values (src/components/common/CreatorCard.tsx).
Add targeted unit/component tests for the new helpers and the card accessibility integration (src/utils/__tests__/creatorDisplayName.utils.test.ts, src/utils/__tests__/creatorPriceChartAccessibility.utils.test.ts, src/components/common/__tests__/CreatorCard.accessibility.test.tsx).
-

## Testing
Testing
Ran the new targeted tests with pnpm exec vitest run src/utils/__tests__/creatorDisplayName.utils.test.ts src/utils/__tests__/creatorPriceChartAccessibility.utils.test.ts src/components/common/__tests__/CreatorCard.accessibility.test.tsx and they passed.
Type-checking with pnpm exec tsc -b completed successfully.
Linting with pnpm lint succeeded and prettier formatting was applied.
Production build with pnpm build completed successfully (Vite emitted size/annotation warnings only).
A full pnpm test run surfaced unrelated existing failures/timeouts in other test files outside this change set, but these failures are pre-existing and not caused by this PR.

- [ ] `pnpm lint`
- [ ] `pnpm build`

## Checklist

- [ ] Linked issue or backlog item
- [ ] Scope is limited to the stated change
- [ ] Updated docs if behavior or setup changed
- [ ] Added screenshots for UI changes when relevant

close #368 