### PR TITLE
feat(client): implement reactive key ownership percentage display wit…

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -33,6 +33,7 @@ import { useNetworkMismatch } from '@/hooks/useNetworkMismatch';
 import showToast from '@/utils/toast.util';
 import { getSignatureErrorMessage } from '@/utils/errorHandling.utils';
 import { formatCompactNumber, formatNumber } from '@/utils/numberFormat.utils';
+import { formatOwnershipPercent } from '@/utils/ownership.utils';
 import PrecisionModeToggle, {
 	type PrecisionMode,
 } from '@/components/common/PrecisionModeToggle';
@@ -453,6 +454,11 @@ function LandingPage() {
 		FEATURED_CREATOR_KEY_HOLDER_COUNT
 	);
 
+	// Choose the featured creator from live data when available, otherwise
+	// fall back to the demo featured creator. This keeps the profile panel
+	// reactive to backend updates (supply, price, etc.).
+	const featuredCreator = creators.length > 0 ? creators[0] : DEMO_CREATORS[0];
+
 	useEffect(() => {
 		if (pendingScrollRestoreRef.current == null) return;
 		const target = pendingScrollRestoreRef.current;
@@ -576,322 +582,405 @@ function LandingPage() {
 					<SectionDivider title="Discover creators" spacing="relaxed" />
 
 					<StickyFilterBar
-					eyebrow="Marketplace filters"
-					title="Find creators without losing your place"
-					description="Search by creator name or handle while you keep scrolling through the marketplace. The filter shell stays visible and compact so you can refine results without losing your place."
-					resultCount={filteredCreators.length}
-					onReset={handleResetSearch}
-					showReset={searchQuery.length > 0}
-				>
-					<div className="space-y-3">
-						<SearchBar
-							value={searchQuery}
-							onChange={setSearchQuery}
-							validationMessage={searchValidationMessage}
-							isLoading={isLoading}
-							className="max-w-none shadow-2xl shadow-black/20"
-						/>
-						<div className="flex items-center gap-3">
-							<label
-								htmlFor="creator-sort"
-								className="marketplace-label-muted text-xs font-semibold uppercase tracking-[0.16em]"
-							>
-								Sort
-							</label>
-							<select
-								id="creator-sort"
-								value={sortOption}
-								onChange={e =>
-									setSortOption(e.target.value as SortOption)
-								}
-								className="h-9 rounded-lg border border-white/15 bg-slate-950/80 px-3 text-sm text-white outline-none focus:border-amber-400/60"
-							>
-								<option value="featured">Featured</option>
-								<option value="price-asc">Price: Low to high</option>
-								<option value="price-desc">Price: High to low</option>
-								<option value="supply-desc">Supply: High to low</option>
-							</select>
-						</div>
-					</div>
-				</StickyFilterBar>
-
-				<SectionDivider title="Marketplace results" spacing="default" />
-
-				<SectionErrorBoundary sectionName="Creator List" minHeight={400}>
-				<MarketplaceSection id="main-creator-list" tabIndex={-1}>
-						<SectionHeading
-							title="Explore creators"
-							supportingText="Discover creator profiles and marketplace listings."
-							className="mb-7"
-							supportingTextClassName="max-w-3xl"
-						/>
-
-						{isLoading ? (
-							<CreatorGridSkeleton count={6} />
-						) : isFilterLoading ? (
-							<div className="space-y-4">
-								<div className="flex items-center justify-center gap-2 py-8">
-									<div className="size-4 animate-spin rounded-full border-2 border-amber-400/20 border-t-amber-400" />
-									<span className="text-sm text-white/60">
-										Updating results...
-									</span>
-								</div>
-								<div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3 opacity-50">
-									{pagedCreators.map(creator => (
-										<CreatorCard key={creator.id} creator={creator} isPriceRefreshing={isPriceRefreshing} />
-									))}
-								</div>
+						eyebrow="Marketplace filters"
+						title="Find creators without losing your place"
+						description="Search by creator name or handle while you keep scrolling through the marketplace. The filter shell stays visible and compact so you can refine results without losing your place."
+						resultCount={filteredCreators.length}
+						onReset={handleResetSearch}
+						showReset={searchQuery.length > 0}
+					>
+						<div className="space-y-3">
+							<SearchBar
+								value={searchQuery}
+								onChange={setSearchQuery}
+								validationMessage={searchValidationMessage}
+								isLoading={isLoading}
+								className="max-w-none shadow-2xl shadow-black/20"
+							/>
+							<div className="flex items-center gap-3">
+								<label
+									htmlFor="creator-sort"
+									className="marketplace-label-muted text-xs font-semibold uppercase tracking-[0.16em]"
+								>
+									Sort
+								</label>
+								<select
+									id="creator-sort"
+									value={sortOption}
+									onChange={e =>
+										setSortOption(e.target.value as SortOption)
+									}
+									className="h-9 rounded-lg border border-white/15 bg-slate-950/80 px-3 text-sm text-white outline-none focus:border-amber-400/60"
+								>
+									<option value="featured">Featured</option>
+									<option value="price-asc">Price: Low to high</option>
+									<option value="price-desc">Price: High to low</option>
+									<option value="supply-desc">Supply: High to low</option>
+								</select>
 							</div>
-						) : filteredCreators.length > 0 ? (
-							<div className="space-y-4">
-								{showRetryBanner && (
-									<TransactionRetryNotice
-										title="Loading live creators"
-										message={getFetchRetryHelperCopy(
-											fetchRetryAttempt + 1,
-											MAX_CREATOR_FETCH_RETRIES + 1
-										)}
-										retryLabel={FETCH_RETRY_ACTION_LABEL}
-										onRetry={handleRetryCreatorFetch}
-									/>
-								)}
-								{finalFetchError && (
-									<div className="rounded-xl border border-amber-500/25 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
-										{finalFetchError}
+						</div>
+					</StickyFilterBar>
+
+					<SectionDivider title="Marketplace results" spacing="default" />
+
+					<SectionErrorBoundary sectionName="Creator List" minHeight={400}>
+						<MarketplaceSection id="main-creator-list" tabIndex={-1}>
+							<SectionHeading
+								title="Explore creators"
+								supportingText="Discover creator profiles and marketplace listings."
+								className="mb-7"
+								supportingTextClassName="max-w-3xl"
+							/>
+
+							{isLoading ? (
+								<CreatorGridSkeleton count={6} />
+							) : isFilterLoading ? (
+								<div className="space-y-4">
+									<div className="flex items-center justify-center gap-2 py-8">
+										<div className="size-4 animate-spin rounded-full border-2 border-amber-400/20 border-t-amber-400" />
+										<span className="text-sm text-white/60">
+											Updating results...
+										</span>
 									</div>
-								)}
-								{/* #301: subtle inline stale-data warning that
+									<div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3 opacity-50">
+										{pagedCreators.map(creator => (
+											<CreatorCard key={creator.id} creator={creator} isPriceRefreshing={isPriceRefreshing} />
+										))}
+									</div>
+								</div>
+							) : filteredCreators.length > 0 ? (
+								<div className="space-y-4">
+									{showRetryBanner && (
+										<TransactionRetryNotice
+											title="Loading live creators"
+											message={getFetchRetryHelperCopy(
+												fetchRetryAttempt + 1,
+												MAX_CREATOR_FETCH_RETRIES + 1
+											)}
+											retryLabel={FETCH_RETRY_ACTION_LABEL}
+											onRetry={handleRetryCreatorFetch}
+										/>
+									)}
+									{finalFetchError && (
+										<div className="rounded-xl border border-amber-500/25 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+											{finalFetchError}
+										</div>
+									)}
+									{/* #301: subtle inline stale-data warning that
 									appears once the cached creator data is past
 									the 60s freshness window. The hook drives a
 									background refresh that resets the baseline
 									and clears the warning automatically. */}
-								{creatorsAreStale && (
-									<StaleDataWarning
-										stale={creatorsAreStale}
-										ageMs={creatorsAgeMs}
-										className="self-start"
+									{creatorsAreStale && (
+										<StaleDataWarning
+											stale={creatorsAreStale}
+											ageMs={creatorsAgeMs}
+											className="self-start"
+										/>
+									)}
+									<LayoutGroup>
+										<div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+											{pagedCreators.map((creator, index) => (
+												// #300: staggered entry animation; the
+												// helper no-ops on prefers-reduced-motion.
+												// #355: layout transition when sort order changes.
+												<motion.div
+													key={creator.id}
+													layout={!prefersReducedMotion}
+													transition={
+														CREATOR_LIST_SORT_LAYOUT_TRANSITION
+													}
+													className={CREATOR_CARD_ENTRY_CLASS}
+													style={creatorCardEntryStyle(index, {
+														prefersReducedMotion,
+													})}
+												>
+													<CreatorCard
+														creator={creator}
+														isPriceRefreshing={isPriceRefreshing}
+													/>
+												</motion.div>
+											))}
+										</div>
+									</LayoutGroup>
+									<CreatorListPagination
+										page={safePage}
+										totalPages={totalPages}
+										onPageChange={handlePageChange}
+										className="mt-8"
 									/>
-								)}
-								<LayoutGroup>
-									<div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
-										{pagedCreators.map((creator, index) => (
-											// #300: staggered entry animation; the
-											// helper no-ops on prefers-reduced-motion.
-											// #355: layout transition when sort order changes.
-											<motion.div
-												key={creator.id}
-												layout={!prefersReducedMotion}
-												transition={
-													CREATOR_LIST_SORT_LAYOUT_TRANSITION
-												}
-												className={CREATOR_CARD_ENTRY_CLASS}
-												style={creatorCardEntryStyle(index, {
-													prefersReducedMotion,
-												})}
+									{safePage < totalPages - 1 && (
+										<div className="mt-4 flex justify-center">
+											<Button
+												type="button"
+												variant="outline"
+												onClick={() => handlePageChange(safePage + 1)}
+												aria-label="Load more creators"
+												className="sr-only rounded-full border-white/10 bg-white/5 px-4 py-2 text-xs font-bold uppercase tracking-[0.18em] text-white shadow-none focus:not-sr-only focus:flex focus:items-center focus:gap-2 focus:outline-none focus:ring-2 focus:ring-amber-400/60 focus:ring-offset-2 focus:ring-offset-slate-950"
 											>
-												<CreatorCard
-													creator={creator}
-													isPriceRefreshing={isPriceRefreshing}
-												/>
-											</motion.div>
-										))}
-									</div>
-								</LayoutGroup>
-								<CreatorListPagination
-									page={safePage}
-									totalPages={totalPages}
-									onPageChange={handlePageChange}
-									className="mt-8"
-								/>
-								{safePage < totalPages - 1 && (
-									<div className="mt-4 flex justify-center">
-										<Button
-											type="button"
-											variant="outline"
-											onClick={() => handlePageChange(safePage + 1)}
-											aria-label="Load more creators"
-											className="sr-only rounded-full border-white/10 bg-white/5 px-4 py-2 text-xs font-bold uppercase tracking-[0.18em] text-white shadow-none focus:not-sr-only focus:flex focus:items-center focus:gap-2 focus:outline-none focus:ring-2 focus:ring-amber-400/60 focus:ring-offset-2 focus:ring-offset-slate-950"
-										>
-											<ChevronDown className="size-4" aria-hidden="true" />
-											Load more creators
-										</Button>
-									</div>
-								)}
+												<ChevronDown className="size-4" aria-hidden="true" />
+												Load more creators
+											</Button>
+										</div>
+									)}
 									{safePage >= totalPages - 1 && (
 										<p
-										role="status"
-										aria-live="polite"
-										className="mt-4 text-center text-xs font-semibold uppercase tracking-[0.18em] text-white/45"
-									>
-										{`You've reached the end — ${formatNumber(filteredCreators.length)} creator${filteredCreators.length === 1 ? '' : 's'} shown.`}
-									</p>
-								)}
-							</div>
-						) : (
-							<div className="flex flex-col items-center gap-6 py-12">
-								{trimmedSearchQuery.length === 0 ? (
-									<ClearedFiltersEmptyState
-										onBrowseAll={handleResetSearch}
-										className="w-full max-w-xl"
-									/>
-								) : (
-									<>
-										<EmptyState
-											image="/images/no-results.png"
-											title="No creators found"
-											description={`We couldn't find any creators matching "${searchQuery}". Try a different name or handle.`}
-											onReset={handleResetSearch}
+											role="status"
+											aria-live="polite"
+											className="mt-4 text-center text-xs font-semibold uppercase tracking-[0.18em] text-white/45"
+										>
+											{`You've reached the end — ${formatNumber(filteredCreators.length)} creator${filteredCreators.length === 1 ? '' : 's'} shown.`}
+										</p>
+									)}
+								</div>
+							) : (
+								<div className="flex flex-col items-center gap-6 py-12">
+									{trimmedSearchQuery.length === 0 ? (
+										<ClearedFiltersEmptyState
+											onBrowseAll={handleResetSearch}
+											className="w-full max-w-xl"
 										/>
-										{!hasInvalidSearchInput && (
-											<EmptySearchSuggestions
-												className="w-full max-w-xl"
-												suggestions={searchSuggestions}
-												onSelect={setSearchQuery}
+									) : (
+										<>
+											<EmptyState
+												image="/images/no-results.png"
+												title="No creators found"
+												description={`We couldn't find any creators matching "${searchQuery}". Try a different name or handle.`}
+												onReset={handleResetSearch}
 											/>
-										)}
-									</>
-								)}
-							</div>
-						)}
-					</MarketplaceSection>
-				</SectionErrorBoundary>
-
-				<SectionDivider title="Creator profile pattern" spacing="relaxed" />
-
-				<div className="mb-8 space-y-6">
-					<CreatorBreadcrumb
-						parentLabel="Marketplace"
-						parentHref="/"
-						currentLabel="Alex Rivers Portfolio"
-					/>
-					<SectionErrorBoundary
-						sectionName="Creator Header"
-						minHeight={150}
-					>
-						{isLoading ? (
-							<CreatorProfileHeaderSkeleton />
-						) : (
-							<CreatorProfileHeader
-								name="Alex Rivers"
-								handle="arivers"
-								creatorId="arivers"
-								isVerified={true}
-								avatarUrl="https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop"
-							/>
-						)}
+											{!hasInvalidSearchInput && (
+												<EmptySearchSuggestions
+													className="w-full max-w-xl"
+													suggestions={searchSuggestions}
+													onSelect={setSearchQuery}
+												/>
+											)}
+										</>
+									)}
+								</div>
+							)}
+						</MarketplaceSection>
 					</SectionErrorBoundary>
-				</div>
 
-				<SectionErrorBoundary sectionName="Creator Profile" minHeight={300}>
-					{finalFetchError ? (
-						<CreatorProfileLoadError
-							onRetry={handleRetryCreatorFetch}
-							isRetrying={isLoading}
+					<SectionDivider title="Creator profile pattern" spacing="relaxed" />
+
+					<div className="mb-8 space-y-6">
+						<CreatorBreadcrumb
+							parentLabel="Marketplace"
+							parentHref="/"
+							currentLabel="Alex Rivers Portfolio"
 						/>
-					) : (
-						<MarketplaceSection
-							spacing="relaxed"
-							className="marketplace-card-surface grid gap-8 rounded-[2rem] border p-6 shadow-[0_24px_80px_-60px_rgba(8,17,31,0.95)] backdrop-blur-sm md:p-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-start"
+						<SectionErrorBoundary
+							sectionName="Creator Header"
+							minHeight={150}
 						>
-							<div>
-								<SectionHeading
-									eyebrow="Profile spotlight"
-									title="A reusable profile facts layout for featured creators"
-									className="mb-4"
+							{isLoading ? (
+								<CreatorProfileHeaderSkeleton />
+							) : (
+								<CreatorProfileHeader
+									name="Alex Rivers"
+									handle="arivers"
+									creatorId="arivers"
+									isVerified={true}
+									avatarUrl="https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop"
 								/>
-								<ProfileTabPillGroup
-									tabs={[
-										{ label: 'Overview', value: 'overview' },
-										{ label: 'Creations', value: 'creations' },
-										{ label: 'Collectors', value: 'collectors' },
-										{ label: 'Activity', value: 'activity' },
-									]}
-									activeTab={activeProfileTab}
-									onTabChange={setActiveProfileTab}
-									enableHashRouting
-									className="mb-4"
-								/>
-								<CompactSectionSubtitle className="max-w-xl">
-									Use the same subtitle pattern beneath headings, then
-									drop repeated creator facts into one responsive grid
-									that stays tidy on mobile and desktop.
-								</CompactSectionSubtitle>
-								<div
-									id={`profile-panel-${activeProfileTab}`}
-									role="tabpanel"
-									aria-labelledby={`profile-tab-${activeProfileTab}`}
-									tabIndex={0}
-								>
-									<div className="mt-5 flex flex-wrap gap-2">
-										<MiniStatChip
-											label="Status"
-											value="Verified creator"
-											explanation="Creator has completed identity verification with Access Layer."
-										/>
-										<MiniStatChip
-											label="Audience"
-											value={featuredCreatorKeyHolderCopy.value}
-											explanation={featuredCreatorKeyHolderCopy.explanation}
-										/>
-										<MiniStatChip
-											label="Access"
-											value="Member-first drops"
-											explanation="Key holders see new drops a window before the public marketplace."
-										/>
+							)}
+						</SectionErrorBoundary>
+					</div>
+
+					<SectionErrorBoundary sectionName="Creator Profile" minHeight={300}>
+						{finalFetchError ? (
+							<CreatorProfileLoadError
+								onRetry={handleRetryCreatorFetch}
+								isRetrying={isLoading}
+							/>
+						) : (
+							<MarketplaceSection
+								spacing="relaxed"
+								className="marketplace-card-surface grid gap-8 rounded-[2rem] border p-6 shadow-[0_24px_80px_-60px_rgba(8,17,31,0.95)] backdrop-blur-sm md:p-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-start"
+							>
+								<div>
+									<SectionHeading
+										eyebrow="Profile spotlight"
+										title="A reusable profile facts layout for featured creators"
+										className="mb-4"
+									/>
+									<ProfileTabPillGroup
+										tabs={[
+											{ label: 'Overview', value: 'overview' },
+											{ label: 'Creations', value: 'creations' },
+											{ label: 'Collectors', value: 'collectors' },
+											{ label: 'Activity', value: 'activity' },
+										]}
+										activeTab={activeProfileTab}
+										onTabChange={setActiveProfileTab}
+										enableHashRouting
+										className="mb-4"
+									/>
+									<CompactSectionSubtitle className="max-w-xl">
+										Use the same subtitle pattern beneath headings, then
+										drop repeated creator facts into one responsive grid
+										that stays tidy on mobile and desktop.
+									</CompactSectionSubtitle>
+									<div
+										id={`profile-panel-${activeProfileTab}`}
+										role="tabpanel"
+										aria-labelledby={`profile-tab-${activeProfileTab}`}
+										tabIndex={0}
+									>
+										<div className="mt-5 flex flex-wrap gap-2">
+											<MiniStatChip
+												label="Status"
+												value="Verified creator"
+												explanation="Creator has completed identity verification with Access Layer."
+											/>
+											<MiniStatChip
+												label="Audience"
+												value={featuredCreatorKeyHolderCopy.value}
+												explanation={featuredCreatorKeyHolderCopy.explanation}
+											/>
+											<MiniStatChip
+												label="Access"
+												value="Member-first drops"
+												explanation="Key holders see new drops a window before the public marketplace."
+											/>
+										</div>
 									</div>
 								</div>
-							</div>
-							<div className="space-y-3">
-								<CreatorProfileInfoGrid
-									items={[
-										...FEATURED_CREATOR_FACTS,
-										{
-											label: 'Followers',
-											value:
-												FEATURED_CREATOR_FOLLOWER_COUNT != null
-													? formatCompactNumber(
+								<div className="space-y-3">
+									<CreatorProfileInfoGrid
+										items={[
+											...FEATURED_CREATOR_FACTS,
+											{
+												label: 'Followers',
+												value:
+													FEATURED_CREATOR_FOLLOWER_COUNT != null
+														? formatCompactNumber(
 															FEATURED_CREATOR_FOLLOWER_COUNT
 														)
-													: 'Not available',
-											helperText:
-												FEATURED_CREATOR_FOLLOWER_COUNT != null
-													? undefined
-													: 'Follower count not available yet.',
-										},
-										{
-											label: 'Your holdings',
-											value: `${formatNumber(featuredHoldings)} keys`,
-										},
-									]}
-								/>
-								<div className="flex items-center justify-between gap-2">
-									<span className="text-[0.65rem] font-bold uppercase tracking-[0.22em] text-white/40">
-										Metrics display
-									</span>
-									<PrecisionModeToggle
-										mode={precisionMode}
-										onChange={setPrecisionMode}
+														: 'Not available',
+												helperText:
+													FEATURED_CREATOR_FOLLOWER_COUNT != null
+														? undefined
+														: 'Follower count not available yet.',
+											},
+											{
+												label: 'Your holdings',
+												value: `${formatNumber(featuredHoldings)} keys${formatOwnershipPercent(
+													featuredHoldings,
+													featuredCreator?.creatorShareSupply,
+													{
+														maximumFractionDigits:
+															precisionMode === 'compact' ? 1 : 2,
+													}
+												) !== '—'
+													? ` (${formatOwnershipPercent(
+														featuredHoldings,
+														featuredCreator?.creatorShareSupply,
+														{
+															maximumFractionDigits:
+																precisionMode === 'compact' ? 1 : 2,
+														}
+													)})`
+													: ''
+													}`,
+											},
+										]}
 									/>
+									<div className="flex items-center justify-between gap-2">
+										<span className="text-[0.65rem] font-bold uppercase tracking-[0.22em] text-white/40">
+											Metrics display
+										</span>
+										<PrecisionModeToggle
+											mode={precisionMode}
+											onChange={setPrecisionMode}
+										/>
+									</div>
+									<CreatorLabeledStatRow
+										label="Creator Share Supply"
+										value={
+											precisionMode === 'compact'
+												? `${formatCompactNumber(
+													featuredCreator?.creatorShareSupply
+												)} shares available`
+												: `${formatNumber(
+													featuredCreator?.creatorShareSupply
+												)} shares available`
+										}
+									/>
+									{isNetworkMismatch && <NetworkMismatchBanner />}
+									<div className="relative">
+										<div
+											className={cn(
+												'hidden md:flex items-center gap-3 transition-opacity duration-200',
+												tradeSubmitting && 'pointer-events-none select-none opacity-60'
+											)}
+											aria-busy={tradeSubmitting || undefined}
+										>
+											<Button
+												className="rounded-xl"
+												onClick={() => openTradeDialog('buy')}
+												disabled={isNetworkMismatch || tradeSubmitting}
+											>
+												Buy
+											</Button>
+											<Button
+												className="rounded-xl"
+												variant="outline"
+												onClick={() => openTradeDialog('sell')}
+												disabled={isNetworkMismatch || tradeSubmitting}
+											>
+												Sell
+											</Button>
+										</div>
+										{tradeSubmitting && (
+											<div className="absolute inset-0 hidden items-center justify-center rounded-[1.25rem] border border-white/10 bg-slate-950/65 backdrop-blur-sm md:flex">
+												<div className="flex items-center gap-2 rounded-full border border-white/10 bg-slate-950/80 px-3 py-1.5 text-xs font-bold text-white/85 shadow-lg">
+													<div className="size-3.5 animate-spin rounded-full border-2 border-amber-400/25 border-t-amber-400" />
+													Submitting trade
+												</div>
+											</div>
+										)}
+									</div>
 								</div>
-								<CreatorLabeledStatRow
-									label="Creator Share Supply"
-									value={
-										precisionMode === 'compact'
-											? `${formatCompactNumber(250)} shares available`
-											: `${formatNumber(250)} shares available`
-									}
-								/>
-								{isNetworkMismatch && <NetworkMismatchBanner />}
+							</MarketplaceSection>
+						)}
+					</SectionErrorBoundary>
+
+					<div className="fixed inset-x-0 bottom-0 z-40 border-t border-white/10 bg-slate-950/85 backdrop-blur-md md:hidden">
+						<div className="mx-auto flex max-w-7xl items-center justify-between gap-3 px-6 py-3">
+							<div className="min-w-0">
+								<div className="text-xs font-bold uppercase tracking-[0.22em] text-white/40">
+									Your holdings
+								</div>
+								<div
+									className="truncate font-jakarta text-sm font-bold text-white/85"
+									aria-label={`Wallet holdings: ${formatNumber(
+										featuredHoldings
+									)} keys${formatOwnershipPercent(featuredHoldings, featuredCreator?.creatorShareSupply) !== '—'
+										? ` (${formatOwnershipPercent(featuredHoldings, featuredCreator?.creatorShareSupply)})`
+										: ''}`}
+								>
+									{formatNumber(featuredHoldings)} keys
+									{formatOwnershipPercent(featuredHoldings, featuredCreator?.creatorShareSupply) !== '—' && (
+										<span className="ml-2 text-xs font-normal text-white/60">
+											({formatOwnershipPercent(featuredHoldings, featuredCreator?.creatorShareSupply)})
+										</span>
+									)}
+								</div>
+							</div>
+							<div className="flex items-center gap-2">
 								<div className="relative">
 									<div
 										className={cn(
-											'hidden md:flex items-center gap-3 transition-opacity duration-200',
+											'flex items-center gap-2 transition-opacity duration-200',
 											tradeSubmitting && 'pointer-events-none select-none opacity-60'
 										)}
 										aria-busy={tradeSubmitting || undefined}
 									>
 										<Button
 											className="rounded-xl"
+											size="sm"
 											onClick={() => openTradeDialog('buy')}
 											disabled={isNetworkMismatch || tradeSubmitting}
 										>
@@ -899,6 +988,7 @@ function LandingPage() {
 										</Button>
 										<Button
 											className="rounded-xl"
+											size="sm"
 											variant="outline"
 											onClick={() => openTradeDialog('sell')}
 											disabled={isNetworkMismatch || tradeSubmitting}
@@ -907,80 +997,26 @@ function LandingPage() {
 										</Button>
 									</div>
 									{tradeSubmitting && (
-										<div className="absolute inset-0 hidden items-center justify-center rounded-[1.25rem] border border-white/10 bg-slate-950/65 backdrop-blur-sm md:flex">
-											<div className="flex items-center gap-2 rounded-full border border-white/10 bg-slate-950/80 px-3 py-1.5 text-xs font-bold text-white/85 shadow-lg">
-												<div className="size-3.5 animate-spin rounded-full border-2 border-amber-400/25 border-t-amber-400" />
+										<div className="absolute inset-0 flex items-center justify-center rounded-xl border border-white/10 bg-slate-950/65 px-3 backdrop-blur-sm">
+											<div className="flex items-center gap-2 rounded-full border border-white/10 bg-slate-950/80 px-3 py-1.5 text-[11px] font-bold text-white/85 shadow-lg">
+												<div className="size-3 animate-spin rounded-full border-2 border-amber-400/25 border-t-amber-400" />
 												Submitting trade
 											</div>
 										</div>
 									)}
 								</div>
 							</div>
-						</MarketplaceSection>
-					)}
-				</SectionErrorBoundary>
-
-				<div className="fixed inset-x-0 bottom-0 z-40 border-t border-white/10 bg-slate-950/85 backdrop-blur-md md:hidden">
-					<div className="mx-auto flex max-w-7xl items-center justify-between gap-3 px-6 py-3">
-						<div className="min-w-0">
-							<div className="text-xs font-bold uppercase tracking-[0.22em] text-white/40">
-								Your holdings
-							</div>
-							<div
-								className="truncate font-jakarta text-sm font-bold text-white/85"
-								aria-label={`Wallet holdings: ${formatNumber(featuredHoldings)} keys`}
-							>
-								{formatNumber(featuredHoldings)} keys
-							</div>
-						</div>
-						<div className="flex items-center gap-2">
-							<div className="relative">
-								<div
-									className={cn(
-										'flex items-center gap-2 transition-opacity duration-200',
-										tradeSubmitting && 'pointer-events-none select-none opacity-60'
-									)}
-									aria-busy={tradeSubmitting || undefined}
-								>
-									<Button
-										className="rounded-xl"
-										size="sm"
-										onClick={() => openTradeDialog('buy')}
-										disabled={isNetworkMismatch || tradeSubmitting}
-									>
-										Buy
-									</Button>
-									<Button
-										className="rounded-xl"
-										size="sm"
-										variant="outline"
-										onClick={() => openTradeDialog('sell')}
-										disabled={isNetworkMismatch || tradeSubmitting}
-									>
-										Sell
-									</Button>
-								</div>
-								{tradeSubmitting && (
-									<div className="absolute inset-0 flex items-center justify-center rounded-xl border border-white/10 bg-slate-950/65 px-3 backdrop-blur-sm">
-										<div className="flex items-center gap-2 rounded-full border border-white/10 bg-slate-950/80 px-3 py-1.5 text-[11px] font-bold text-white/85 shadow-lg">
-											<div className="size-3 animate-spin rounded-full border-2 border-amber-400/25 border-t-amber-400" />
-											Submitting trade
-										</div>
-									</div>
-								)}
-							</div>
 						</div>
 					</div>
-				</div>
 
-				<SectionDivider
-					title="Transaction timeline pattern"
-					spacing="relaxed"
-					isEmpty={false}
-				/>
-				<MarketplaceSection spacing="relaxed">
-					<EmptyTransactionTimelineState />
-				</MarketplaceSection>
+					<SectionDivider
+						title="Transaction timeline pattern"
+						spacing="relaxed"
+						isEmpty={false}
+					/>
+					<MarketplaceSection spacing="relaxed">
+						<EmptyTransactionTimelineState />
+					</MarketplaceSection>
 				</main>
 			</div>
 
@@ -989,7 +1025,7 @@ function LandingPage() {
 				side={tradeSide}
 				creatorName="Alex Rivers"
 				availableHoldings={featuredHoldings}
-				keyPriceStroops={resolveCreatorKeyPriceStroops(DEMO_CREATORS[0])}
+				keyPriceStroops={resolveCreatorKeyPriceStroops(featuredCreator)}
 				isSubmitting={tradeSubmitting}
 				onOpenChange={setTradeDialogOpen}
 				onConfirm={handleConfirmTrade}

--- a/src/utils/__tests__/ownership.utils.test.ts
+++ b/src/utils/__tests__/ownership.utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+    computeOwnershipPercentage,
+    formatOwnershipPercent,
+} from '../ownership.utils';
+
+describe('ownership.utils', () => {
+    describe('computeOwnershipPercentage', () => {
+        it('returns null when balance is null', () => {
+            expect(computeOwnershipPercentage(null, 100)).toBeNull();
+        });
+
+        it('returns null when totalSupply is null', () => {
+            expect(computeOwnershipPercentage(10, null)).toBeNull();
+        });
+
+        it('returns null when totalSupply is zero or negative', () => {
+            expect(computeOwnershipPercentage(10, 0)).toBeNull();
+            expect(computeOwnershipPercentage(10, -5)).toBeNull();
+        });
+
+        it('computes correct percentage for normal values', () => {
+            expect(computeOwnershipPercentage(25, 100)).toBeCloseTo(25);
+            expect(computeOwnershipPercentage(1, 3)).toBeCloseTo((1 / 3) * 100);
+        });
+
+        it('handles balances greater than supply ( >100%)', () => {
+            expect(computeOwnershipPercentage(150, 100)).toBeCloseTo(150);
+        });
+
+        it('returns null for non-finite inputs', () => {
+            expect(computeOwnershipPercentage(NaN, 100)).toBeNull();
+            expect(computeOwnershipPercentage(10, Infinity)).toBeNull();
+        });
+    });
+
+    describe('formatOwnershipPercent', () => {
+        it('returns placeholder when percentage cannot be computed', () => {
+            expect(formatOwnershipPercent(null, 100)).toBe('—');
+            expect(formatOwnershipPercent(10, 0)).toBe('—');
+        });
+
+        it('formats percentage with default precision', () => {
+            expect(formatOwnershipPercent(1, 4)).toBe('25%');
+            expect(formatOwnershipPercent(1, 3)).toBe('33.33%');
+        });
+
+        it('respects maximumFractionDigits option', () => {
+            expect(formatOwnershipPercent(1, 3, { maximumFractionDigits: 1 })).toBe(
+                '33.3%'
+            );
+        });
+
+        it('handles large balances and supplies', () => {
+            expect(formatOwnershipPercent(1_000_000, 10_000_000)).toBe('10%');
+        });
+
+        it('can show signed positives when requested', () => {
+            expect(
+                formatOwnershipPercent(1, 4, { signed: true, maximumFractionDigits: 0 })
+            ).toBe('+25%');
+        });
+    });
+});

--- a/src/utils/ownership.utils.ts
+++ b/src/utils/ownership.utils.ts
@@ -1,0 +1,36 @@
+import { formatPercent } from '@/utils/numberFormat.utils';
+
+export interface FormatOwnershipOptions {
+    maximumFractionDigits?: number;
+    minimumFractionDigits?: number;
+    signed?: boolean;
+}
+
+export function computeOwnershipPercentage(
+    balance: number | null | undefined,
+    totalSupply: number | null | undefined
+): number | null {
+    if (balance == null || totalSupply == null) return null;
+    if (!Number.isFinite(balance) || !Number.isFinite(totalSupply)) return null;
+    if (totalSupply <= 0) return null;
+    return (balance / totalSupply) * 100;
+}
+
+export function formatOwnershipPercent(
+    balance: number | null | undefined,
+    totalSupply: number | null | undefined,
+    options: FormatOwnershipOptions = {}
+): string {
+    const pct = computeOwnershipPercentage(balance, totalSupply);
+    if (pct == null) return '—';
+    return formatPercent(pct, {
+        maximumFractionDigits: options.maximumFractionDigits ?? 2,
+        minimumFractionDigits: options.minimumFractionDigits ?? 0,
+        signed: options.signed ?? false,
+    });
+}
+
+export default {
+    computeOwnershipPercentage,
+    formatOwnershipPercent,
+};


### PR DESCRIPTION

## Summary
Closes #374. Introduces a front-end math utility layer and UI helper to calculate, format, and render a connected wallet's exact key holding ownership percentage relative to a creator's dynamic circulating supply.

## What Changed
- **Defensive Calculation Engine (`ownership.utils.ts`):** Authored safe floating-point percentage math that cleanly intercepts zero-supply edge cases and formats readable strings.
- **Reactive State Mapping (`LandingPage.tsx`):** Tied the dashboard stat bar and mobile holdings indicator to read reactively from `featuredCreator.creatorShareSupply` instead of hardcoded demo integers.
- **Robust Verification Suite (`ownership.utils.test.ts`):** Implemented unit tests checking precision rounding, zero-division blocks, and overflow thresholds.

## Testing & Validation
- [x] Confirmed a flawless execution cycle across all 11 calculation edge cases locally via `pnpm test`.
- [x] Verified zero layout regression or TypeScript compile errors during production compilation passes.


Closes #374 
