### PR TITLE
test: add integration tests for MarketingPage community links

### DIFF
--- a/src/pages/__tests__/MarketingPage.test.tsx
+++ b/src/pages/__tests__/MarketingPage.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import MarketingPage from '@/pages/MarketingPage';
+
+describe('MarketingPage community links', () => {
+	it('GitHub link points to the correct URL and opens in a new tab', () => {
+		render(<MarketingPage />);
+
+		const githubLink = screen.getByRole('link', { name: /github/i });
+
+		expect(githubLink).toHaveAttribute('href', 'https://github.com/accesslayerorg');
+		expect(githubLink).toHaveAttribute('target', '_blank');
+		expect(githubLink).toHaveAttribute('rel', 'noopener noreferrer');
+	});
+
+	it('Telegram link points to the correct URL and opens in a new tab', () => {
+		render(<MarketingPage />);
+
+		const telegramLink = screen.getByRole('link', { name: /telegram/i });
+
+		expect(telegramLink).toHaveAttribute('href', 'https://t.me/c/accesslayerorg/');
+		expect(telegramLink).toHaveAttribute('target', '_blank');
+		expect(telegramLink).toHaveAttribute('rel', 'noopener noreferrer');
+	});
+});


### PR DESCRIPTION

Closes #428

> ## Summary

> * Renders `MarketingPage` in the test environment and asserts the GitHub link href is `https://github.com/accesslayerorg`
> * Asserts the Telegram link href is `https://t.me/c/accesslayerorg/`
> * Confirms both links carry `target="_blank"` and `rel="noopener noreferrer"` so a refactor cannot silently break these values
> 
> ## Test plan
> * [x]  GitHub link href is correct
> * [x]  Telegram link href is correct
> * [x]  Both links open in a new tab with the correct `rel` attribute


