### PR TITLE
feat: add shortenAddress helper for wallet address display — Close #423

### DIFF
--- a/src/lib/web3/__tests__/format.test.ts
+++ b/src/lib/web3/__tests__/format.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { shortenAddress } from '../format';
+
+describe('shortenAddress', () => {
+	it('shortens a standard Stellar address to first 4 + ... + last 4', () => {
+		const address = 'GABCDEFGHIJKLMNOPQRSTUVWXYZ1234';
+		expect(shortenAddress(address)).toBe('GABC...1234');
+	});
+
+	it('returns the full address unchanged when it is shorter than 10 characters', () => {
+		const address = 'GABCDEFG';
+		expect(shortenAddress(address)).toBe('GABCDEFG');
+	});
+
+	it('returns the full address unchanged when it is exactly 9 characters', () => {
+		const address = 'GABCDEFGH';
+		expect(shortenAddress(address)).toBe('GABCDEFGH');
+	});
+
+	it('shortens an address that is exactly 10 characters', () => {
+		const address = 'GABCDEFGHI';
+		expect(shortenAddress(address)).toBe('GABC...FGHI');
+	});
+
+	it('returns an empty string when given an empty string', () => {
+		expect(shortenAddress('')).toBe('');
+	});
+});

--- a/src/lib/web3/format.ts
+++ b/src/lib/web3/format.ts
@@ -1,8 +1,5 @@
-export function shortenAddress(
-	address: string,
-	startLength = 6,
-	endLength = 4
-) {
+export function shortenAddress(address: string) {
 	if (!address) return '';
-	return `${address.slice(0, startLength)}...${address.slice(-endLength)}`;
+	if (address.length < 10) return address;
+	return `${address.slice(0, 4)}...${address.slice(-4)}`;
 }


### PR DESCRIPTION
## Summary

Adds a `shortenAddress` utility to format long Stellar wallet addresses for UI display. Full addresses are shortened to **first 4 + `...` + last 4** characters (e.g. `GABC...XY12`).

Closes #423

## Changes

- **`src/lib/web3/format.ts`** — Simplified `shortenAddress(address)` to:
  - Return the full address unchanged when shorter than 10 characters
  - Otherwise return `first 4 + ... + last 4`
  - Return empty string for falsy input
- **`src/lib/web3/__tests__/format.test.ts`** — New test file with 5 unit tests covering:
  - Standard Stellar address → correctly shortened (`GABC...1234`)
  - Address shorter than 10 characters → returned as-is
  - Exactly 9-character address → returned as-is
  - Exactly 10-character address → correctly shortened
  - Empty string → returns empty string

## Acceptance Criteria

- [x] Standard Stellar address returns correctly shortened form
- [x] Addresses shorter than 10 characters are returned as-is
- [x] Unit tests cover all cases

## Testing

```bash
pnpm vitest run src/lib/web3/__tests__/format.test.ts

# Output:
#  ✓ src/lib/web3/__tests__/format.test.ts (5 tests)
# Test Files  1 passed (1)
#      Tests  5 passed (5)
```