### PR TITLE
Add formatHolderCount helper for compact holder display.

### DIFF
--- a/src/utils/__tests__/numberFormat.utils.test.ts
+++ b/src/utils/__tests__/numberFormat.utils.test.ts
@@ -3,6 +3,7 @@ import {
 	formatNumber,
 	formatCompactNumber,
 	formatFollowerCount,
+	formatHolderCount,
 	formatPercent,
 } from '../numberFormat.utils';
 
@@ -142,6 +143,34 @@ describe('formatFollowerCount: Legacy follower abbreviation', () => {
 
 	it('removes ".0" suffix: 1,000 → "1K" not "1.0K"', () => {
 		expect(formatFollowerCount(1000)).toBe('1K');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Feature: Holder count formatting
+// Validates: Issue #438 acceptance criteria
+// ---------------------------------------------------------------------------
+describe('formatHolderCount: Holder count abbreviation', () => {
+	it('returns values under 1000 as a plain string', () => {
+		expect(formatHolderCount(0)).toBe('0');
+		expect(formatHolderCount(42)).toBe('42');
+		expect(formatHolderCount(999)).toBe('999');
+	});
+
+	it('formats values in the K range with one decimal place', () => {
+		expect(formatHolderCount(1200)).toBe('1.2K');
+		expect(formatHolderCount(1500)).toBe('1.5K');
+		expect(formatHolderCount(999_999)).toBe('1000K');
+	});
+
+	it('formats values in the M range with one decimal place', () => {
+		expect(formatHolderCount(2_400_000)).toBe('2.4M');
+		expect(formatHolderCount(1_250_000)).toBe('1.3M');
+	});
+
+	it('handles boundary values at 1000 and 1000000', () => {
+		expect(formatHolderCount(1000)).toBe('1K');
+		expect(formatHolderCount(1_000_000)).toBe('1M');
 	});
 });
 

--- a/src/utils/numberFormat.utils.ts
+++ b/src/utils/numberFormat.utils.ts
@@ -45,7 +45,14 @@ export function formatCompactNumber(
 	return formatNumber(value, { ...options, style: 'compact' });
 }
 
-export function formatFollowerCount(count: number): string {
+/**
+ * Formats holder counts for compact display across creator profile surfaces.
+ *
+ * - Below 1,000: plain string (e.g. `999`)
+ * - 1,000–999,999: one decimal K suffix (e.g. `1.2K`, `1K` at exactly 1,000)
+ * - 1,000,000+: one decimal M suffix (e.g. `2.4M`, `1M` at exactly 1,000,000)
+ */
+export function formatHolderCount(count: number): string {
 	if (count >= 1_000_000) {
 		return `${(count / 1_000_000).toFixed(1).replace(/\.0$/, '')}M`;
 	}
@@ -53,6 +60,10 @@ export function formatFollowerCount(count: number): string {
 		return `${(count / 1_000).toFixed(1).replace(/\.0$/, '')}K`;
 	}
 	return count.toString();
+}
+
+export function formatFollowerCount(count: number): string {
+	return formatHolderCount(count);
 }
 
 export interface FormatPercentOptions {


### PR DESCRIPTION

## Summary


This batch covers four contributor and UX improvements across docs, formatting, empty states, and test coverage:

Closes #439  — Added a Shared utility helpers section to CONTRIBUTING.md documenting address shortening, URL/handle/price formatting helpers with input/output examples, and a note to add new formatting logic in src/utils/ instead of inline in components.



Closes #441  — Added integration tests for Change24hBadge direction indicators (up/down/none for positive, negative, and zero change) and fixed zero-change behavior so it no longer shows the minus icon.


Closes #440  — Added EmptyCreatorList for zero-result creator searches with a readable message and Clear search button; wired it into LandingPage with component and landing-page tests.



Closes #438  — Added formatHolderCount() in numberFormat.utils.ts for compact holder counts (999, 1.2K, 2.4M) with unit tests for each range and boundary values at 1,000 and 1,000,000.
Test plan






## Testing

- [ ] `pnpm lint`
- [ ] `pnpm build`

## Checklist

- [ ] Linked issue or backlog item
- [ ] Scope is limited to the stated change
- [ ] Updated docs if behavior or setup changed
- [ ] Added screenshots for UI changes when relevant
