### PR TITLE
test: add query key integration tests and placeholder hooks

### DIFF
--- a/src/hooks/__tests__/queryKeyIntegration.test.tsx
+++ b/src/hooks/__tests__/queryKeyIntegration.test.tsx
@@ -1,0 +1,55 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+import { queryKeys } from '@/lib/queryKeys';
+import { useCreatorList, useCreatorDetail } from '../useCreators';
+import { useWalletHoldings, useWalletActivity } from '../useWallet';
+
+describe('queryKeyIntegration', () => {
+	let queryClient: QueryClient;
+
+	beforeEach(() => {
+		queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false } },
+		});
+	});
+
+	const wrapper = ({ children }: { children: React.ReactNode }) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+
+	it('useCreatorList uses the correct query key constant', () => {
+		const params = { page: 1 };
+		renderHook(() => useCreatorList(params), { wrapper });
+
+		const cache = queryClient.getQueryCache().getAll();
+		expect(cache).toHaveLength(1);
+		expect(cache[0].queryKey).toEqual(queryKeys.creators.list(params));
+	});
+
+	it('useCreatorDetail uses the correct query key constant', () => {
+		renderHook(() => useCreatorDetail('creator-1'), { wrapper });
+
+		const cache = queryClient.getQueryCache().getAll();
+		expect(cache).toHaveLength(1);
+		expect(cache[0].queryKey).toEqual(queryKeys.creators.detail('creator-1'));
+	});
+
+	it('useWalletHoldings uses the correct query key constant', () => {
+		renderHook(() => useWalletHoldings('0x123'), { wrapper });
+
+		const cache = queryClient.getQueryCache().getAll();
+		expect(cache).toHaveLength(1);
+		expect(cache[0].queryKey).toEqual(queryKeys.wallet.holdings('0x123'));
+	});
+
+	it('useWalletActivity uses the correct query key constant', () => {
+		renderHook(() => useWalletActivity('0x123'), { wrapper });
+
+		const cache = queryClient.getQueryCache().getAll();
+		expect(cache).toHaveLength(1);
+		expect(cache[0].queryKey).toEqual(queryKeys.wallet.activity('0x123'));
+	});
+});

--- a/src/hooks/useCreators.ts
+++ b/src/hooks/useCreators.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queryKeys';
+import type { GetCoursesParams } from '@/services/course.service';
+
+export function useCreatorList(params?: GetCoursesParams) {
+	return useQuery({
+		queryKey: queryKeys.creators.list(params),
+		queryFn: async () => [],
+	});
+}
+
+export function useCreatorDetail(id: string) {
+	return useQuery({
+		queryKey: queryKeys.creators.detail(id),
+		queryFn: async () => null,
+		enabled: !!id,
+	});
+}

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queryKeys';
+
+export function useWalletHoldings(address: string) {
+	return useQuery({
+		queryKey: queryKeys.wallet.holdings(address),
+		queryFn: async () => [],
+		enabled: !!address,
+	});
+}
+
+export function useWalletActivity(address: string) {
+	return useQuery({
+		queryKey: queryKeys.wallet.activity(address),
+		queryFn: async () => [],
+		enabled: !!address,
+	});
+}


### PR DESCRIPTION
# Summary

## Closes #459

Adds the missing data-fetching hooks (as placeholders) and the requested integration test to guarantee query key consistency across the app.

## What Changed

* Added `useCreators.ts` exporting `useCreatorList` and `useCreatorDetail`
* Added `useWallet.ts` exporting `useWalletHoldings` and `useWalletActivity`
* Added `queryKeyIntegration.test.tsx` to assert strict cache-key equivalence with `queryKeys.ts`

## Key Design Decisions

* **Missing Hooks:** The hooks requested in the issue scope were missing from the codebase entirely. To fulfill the requirements of this integration test without inventing complex business logic, minimal placeholder hooks were created that strictly bind to the React Query constants.
* **Testing Approach:** Tests capture the query key directly from the `QueryClient` cache upon component render to guarantee the key generated internally matches the exported constant perfectly.

## Acceptance Criteria Checklist

* [x] Each hook's query key matches the corresponding constant
* [x] Test fails if a hook is updated to use a different key without updating the constant

## Test Output & Coverage

```text
 ✓ src/hooks/__tests__/queryKeyIntegration.test.tsx (4 tests) 74ms
   ✓ queryKeyIntegration (4)
     ✓ useCreatorList uses the correct query key constant 61ms
     ✓ useCreatorDetail uses the correct query key constant 4ms
     ✓ useWalletHoldings uses the correct query key constant 3ms
     ✓ useWalletActivity uses the correct query key constant 2ms

```

```text
-----------------|---------|----------|---------|---------|-------------------
File             | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-----------------|---------|----------|---------|---------|-------------------
All files        |   92.85 |       50 |    92.3 |   92.85 |                   
 hooks           |     100 |      100 |     100 |     100 |                   
  useCreators.ts |     100 |      100 |     100 |     100 |                   
  useWallet.ts   |     100 |      100 |     100 |     100 |                   
-----------------|---------|----------|---------|---------|-------------------

```

## Security Note

Placeholder hooks do not introduce new user inputs, network surface area, or hardcoded secrets.

## Follow-Ups

* Replace the `queryFn` placeholder promises with real API logic when the endpoints are finalized.