### PR TITLE
[codex] Address creator list stability, filters, and hook docs

### DIFF
--- a/docs/shared-hooks.md
+++ b/docs/shared-hooks.md
@@ -1,0 +1,52 @@
+# Contributing Shared Hooks
+
+The `src/hooks` folder is for reusable stateful logic that is not specific to
+one component. Put a hook here when multiple screens or components can share the
+same state management, browser event handling, async coordination, or derived
+behavior. Keep component-only logic near the component that owns it.
+
+## Naming
+
+Shared hooks must:
+
+- Start with the `use` prefix.
+- Export a hook whose name matches the file name.
+- Use a file name that is identical to the hook name, for example
+  `useExample.ts`.
+
+## Tests
+
+Every shared hook must include a corresponding test file in
+`src/hooks/__tests__`. Name the test after the hook, for example
+`useExample.test.ts` or `useExample.test.tsx`.
+
+## Minimal Example
+
+```ts
+// src/hooks/useCounter.ts
+import { useCallback, useState } from 'react';
+
+export const useCounter = (initialValue = 0) => {
+	const [count, setCount] = useState(initialValue);
+	const increment = useCallback(() => setCount(value => value + 1), []);
+
+	return { count, increment };
+};
+```
+
+```ts
+// src/hooks/__tests__/useCounter.test.ts
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useCounter } from '@/hooks/useCounter';
+
+describe('useCounter', () => {
+	it('increments from the initial value', () => {
+		const { result } = renderHook(() => useCounter(2));
+
+		act(() => result.current.increment());
+
+		expect(result.current.count).toBe(3);
+	});
+});
+```

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -62,6 +62,7 @@ import {
 } from '@/utils/portfolioValue.utils';
 import { usePrefersReducedMotion } from '@/hooks/usePrefersReducedMotion';
 import { CREATOR_LIST_SORT_LAYOUT_TRANSITION } from '@/utils/creatorListSortTransition';
+import { creatorListKey } from '@/utils/creatorListKey.utils';
 import { AlertCircle, ChevronDown, RefreshCw } from 'lucide-react';
 import ClearedFiltersEmptyState from '@/components/common/ClearedFiltersEmptyState';
 import CreatorListPagination from '@/components/common/CreatorListPagination';
@@ -228,6 +229,15 @@ const isCreatorRefreshShortcut = (event: KeyboardEvent) =>
 	!event.shiftKey &&
 	event.key.toLowerCase() === 'r';
 
+const toPriceFilterValue = (value: string) => {
+	if (!value.trim()) return undefined;
+	const parsed = Number(value);
+	return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined;
+};
+
+const getCreatorListKey = (creator: Course) =>
+	creatorListKey(Number(creator.id));
+
 type SortOption = 'featured' | 'price-asc' | 'price-desc' | 'supply-desc';
 
 interface CreatorProfileLoadErrorProps {
@@ -283,6 +293,8 @@ function LandingPage() {
 	const [isFilterLoading, setIsFilterLoading] = useState(false);
 	const [searchParams, setSearchParams] = useSearchParams();
 	const [searchQuery, setSearchQuery] = useState('');
+	const [minPriceFilter, setMinPriceFilter] = useState('');
+	const [maxPriceFilter, setMaxPriceFilter] = useState('');
 	const searchQueryRef = useRef<string>('');
 	const sortOptionRef = useRef<SortOption>('featured');
 	const PROFILE_TABS = ['overview', 'creations', 'collectors', 'activity'];
@@ -299,7 +311,10 @@ function LandingPage() {
 	const prefersReducedMotion = usePrefersReducedMotion();
 	const [sortOption, setSortOption] = useState<SortOption>(() => {
 		const sort = searchParams.get('sort') as SortOption | null;
-		if (sort && ['featured', 'price-asc', 'price-desc', 'supply-desc'].includes(sort)) {
+		if (
+			sort &&
+			['featured', 'price-asc', 'price-desc', 'supply-desc'].includes(sort)
+		) {
 			sortOptionRef.current = sort;
 			return sort;
 		}
@@ -386,7 +401,13 @@ function LandingPage() {
 			setSearchQuery('');
 		}
 		const sort = searchParams.get('sort') as SortOption | null;
-		if (sort && ['featured', 'price-asc', 'price-desc', 'supply-desc'].includes(sort) && sort !== sortOptionRef.current) {
+		if (
+			sort &&
+			['featured', 'price-asc', 'price-desc', 'supply-desc'].includes(
+				sort
+			) &&
+			sort !== sortOptionRef.current
+		) {
 			setSortOption(sort);
 		} else if (sort === null && sortOptionRef.current !== 'featured') {
 			setSortOption('featured');
@@ -447,7 +468,15 @@ function LandingPage() {
 			setShowRetryBanner(false);
 			setFinalFetchError('');
 			try {
-				const data = await courseService.getCourses();
+				const minPrice = toPriceFilterValue(minPriceFilter);
+				const maxPrice = toPriceFilterValue(maxPriceFilter);
+				const params = {
+					...(minPrice !== undefined ? { min_price: minPrice } : {}),
+					...(maxPrice !== undefined ? { max_price: maxPrice } : {}),
+				};
+				const data = await courseService.getCourses(
+					Object.keys(params).length > 0 ? params : undefined
+				);
 				if (data && data.length > 0) {
 					setCreators(data);
 				} else {
@@ -458,6 +487,11 @@ function LandingPage() {
 				setCreatorsFetchedAt(Date.now());
 				setFetchRetryAttempt(0);
 			} catch {
+				if (fetchRetryAttempt === 0) {
+					showToast.error(
+						'Unable to load creators. Check your connection and try again.'
+					);
+				}
 				if (fetchRetryAttempt < MAX_CREATOR_FETCH_RETRIES) {
 					const nextAttempt = fetchRetryAttempt + 1;
 					setShowRetryBanner(true);
@@ -482,7 +516,7 @@ function LandingPage() {
 		};
 
 		fetchCreators();
-	}, [fetchRetryAttempt, fetchRequestId]);
+	}, [fetchRetryAttempt, fetchRequestId, maxPriceFilter, minPriceFilter]);
 
 	const searchSuggestions = useMemo(() => {
 		const fromCategories = creators
@@ -581,6 +615,10 @@ function LandingPage() {
 	};
 
 	const handleResetSearch = () => setSearchQuery('');
+	const handleClearPriceFilters = () => {
+		setMinPriceFilter('');
+		setMaxPriceFilter('');
+	};
 
 	const handleRetryCreatorFetch = useCallback(() => {
 		setFinalFetchError('');
@@ -824,6 +862,57 @@ function LandingPage() {
 									</option>
 								</select>
 							</div>
+							<div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] sm:items-end">
+								<div>
+									<label
+										htmlFor="min-price"
+										className="marketplace-label-muted text-xs font-semibold uppercase tracking-[0.16em]"
+									>
+										Min price
+									</label>
+									<input
+										id="min-price"
+										type="number"
+										min="0"
+										step="0.01"
+										inputMode="decimal"
+										value={minPriceFilter}
+										onChange={event =>
+											setMinPriceFilter(event.target.value)
+										}
+										className="mt-1 h-10 w-full rounded-lg border border-white/15 bg-slate-950/80 px-3 text-sm text-white outline-none focus:border-amber-400/60"
+									/>
+								</div>
+								<div>
+									<label
+										htmlFor="max-price"
+										className="marketplace-label-muted text-xs font-semibold uppercase tracking-[0.16em]"
+									>
+										Max price
+									</label>
+									<input
+										id="max-price"
+										type="number"
+										min="0"
+										step="0.01"
+										inputMode="decimal"
+										value={maxPriceFilter}
+										onChange={event =>
+											setMaxPriceFilter(event.target.value)
+										}
+										className="mt-1 h-10 w-full rounded-lg border border-white/15 bg-slate-950/80 px-3 text-sm text-white outline-none focus:border-amber-400/60"
+									/>
+								</div>
+								<Button
+									type="button"
+									variant="outline"
+									onClick={handleClearPriceFilters}
+									disabled={!minPriceFilter && !maxPriceFilter}
+									className="h-10 rounded-lg border-white/10 bg-white/5 px-4 text-xs font-bold uppercase tracking-[0.16em] text-white"
+								>
+									Clear
+								</Button>
+							</div>
 							<div
 								aria-label={`${CREATOR_REFRESH_SHORTCUT_LABEL} refreshes creator list data`}
 								className="flex flex-wrap items-center gap-2 text-xs text-white/55"
@@ -831,7 +920,10 @@ function LandingPage() {
 								<span className="font-semibold uppercase tracking-[0.16em] text-white/40">
 									Shortcut
 								</span>
-								<span className="inline-flex items-center gap-1" aria-hidden="true">
+								<span
+									className="inline-flex items-center gap-1"
+									aria-hidden="true"
+								>
 									<Kbd className="border border-white/10 bg-white/10 text-white/70">
 										Ctrl/Cmd
 									</Kbd>
@@ -857,6 +949,23 @@ function LandingPage() {
 								className="mb-7"
 								supportingTextClassName="max-w-3xl"
 							/>
+							{showRetryBanner && (
+								<TransactionRetryNotice
+									title="Loading live creators"
+									message={getFetchRetryHelperCopy(
+										fetchRetryAttempt + 1,
+										MAX_CREATOR_FETCH_RETRIES + 1
+									)}
+									retryLabel={FETCH_RETRY_ACTION_LABEL}
+									onRetry={handleRetryCreatorFetch}
+									className="mb-6"
+								/>
+							)}
+							{finalFetchError && (
+								<div className="mb-6 rounded-xl border border-amber-500/25 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+									{finalFetchError}
+								</div>
+							)}
 
 							{isLoading ? (
 								<CreatorGridSkeleton count={6} />
@@ -871,7 +980,7 @@ function LandingPage() {
 									<div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3 opacity-50">
 										{pagedCreators.map(creator => (
 											<CreatorCard
-												key={creator.id}
+												key={getCreatorListKey(creator)}
 												creator={creator}
 												isPriceRefreshing={isPriceRefreshing}
 											/>
@@ -880,22 +989,6 @@ function LandingPage() {
 								</div>
 							) : filteredCreators.length > 0 ? (
 								<div className="space-y-4">
-									{showRetryBanner && (
-										<TransactionRetryNotice
-											title="Loading live creators"
-											message={getFetchRetryHelperCopy(
-												fetchRetryAttempt + 1,
-												MAX_CREATOR_FETCH_RETRIES + 1
-											)}
-											retryLabel={FETCH_RETRY_ACTION_LABEL}
-											onRetry={handleRetryCreatorFetch}
-										/>
-									)}
-									{finalFetchError && (
-										<div className="rounded-xl border border-amber-500/25 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
-											{finalFetchError}
-										</div>
-									)}
 									{/* #301: subtle inline stale-data warning that
 									appears once the cached creator data is past
 									the 60s freshness window. The hook drives a
@@ -918,7 +1011,7 @@ function LandingPage() {
 													// helper no-ops on prefers-reduced-motion.
 													// #355: layout transition when sort order changes.
 													<motion.div
-														key={creator.id}
+														key={getCreatorListKey(creator)}
 														layout={!prefersReducedMotion}
 														transition={
 															CREATOR_LIST_SORT_LAYOUT_TRANSITION
@@ -930,14 +1023,20 @@ function LandingPage() {
 													>
 														<CreatorCard
 															creator={creator}
-															isPriceRefreshing={isPriceRefreshing}
+															isPriceRefreshing={
+																isPriceRefreshing
+															}
 														/>
 													</motion.div>
 												))}
 
 											{/* Separator between pinned and unpinned */}
-											{pagedCreators.some(creator => creator.isPinned) &&
-												pagedCreators.some(creator => !creator.isPinned) && (
+											{pagedCreators.some(
+												creator => creator.isPinned
+											) &&
+												pagedCreators.some(
+													creator => !creator.isPinned
+												) && (
 													<CreatorListGroupSeparator label="Other creators" />
 												)}
 
@@ -946,7 +1045,7 @@ function LandingPage() {
 												.filter(creator => !creator.isPinned)
 												.map((creator, index) => (
 													<motion.div
-														key={creator.id}
+														key={getCreatorListKey(creator)}
 														layout={!prefersReducedMotion}
 														transition={
 															CREATOR_LIST_SORT_LAYOUT_TRANSITION
@@ -958,7 +1057,9 @@ function LandingPage() {
 													>
 														<CreatorCard
 															creator={creator}
-															isPriceRefreshing={isPriceRefreshing}
+															isPriceRefreshing={
+																isPriceRefreshing
+															}
 														/>
 													</motion.div>
 												))}

--- a/src/pages/__tests__/LandingPage.apiErrorToast.integration.test.tsx
+++ b/src/pages/__tests__/LandingPage.apiErrorToast.integration.test.tsx
@@ -1,0 +1,138 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import LandingPage from '@/pages/LandingPage';
+import { courseService } from '@/services/course.service';
+import showToast from '@/utils/toast.util';
+
+vi.mock('@/services/course.service', () => ({
+	courseService: { getCourses: vi.fn() },
+}));
+
+vi.mock('@/utils/toast.util', () => ({
+	default: {
+		message: vi.fn(),
+		success: vi.fn(),
+		error: vi.fn(),
+		loading: vi.fn(),
+		transactionSuccess: vi.fn(),
+	},
+}));
+
+vi.mock('@/hooks/useNetworkMismatch', () => ({
+	useNetworkMismatch: () => ({
+		isMismatch: false,
+		expectedChainName: 'Stellar Testnet',
+	}),
+}));
+
+vi.mock('@/hooks/useStaleData', () => ({
+	useStaleData: () => ({
+		stale: false,
+		ageMs: 0,
+		msUntilStale: 60_000,
+		revalidate: vi.fn(),
+	}),
+}));
+
+vi.mock('@/components/common/StellarConnectionQualityBadge', async () => {
+	const React = await import('react');
+
+	return {
+		default: () => React.createElement('div', { role: 'status' }, 'RPC good'),
+	};
+});
+
+vi.mock('@/components/common/CreatorCard', async () => {
+	const React = await import('react');
+
+	return {
+		default: ({ creator }: { creator: { title: string } }) =>
+			React.createElement(
+				'article',
+				{ 'aria-label': `Creator ${creator.title}` },
+				creator.title
+			),
+	};
+});
+
+vi.mock('framer-motion', async () => {
+	const React = await import('react');
+	type MotionDivProps = ComponentProps<'div'> & {
+		layout?: boolean;
+		transition?: unknown;
+	};
+
+	return {
+		AnimatePresence: ({ children }: { children: ReactNode }) =>
+			React.createElement(React.Fragment, null, children),
+		LayoutGroup: ({ children }: { children: ReactNode }) =>
+			React.createElement(React.Fragment, null, children),
+		motion: {
+			div: ({ children, ...props }: MotionDivProps) => {
+				const { layout, transition, ...divProps } = props;
+				void layout;
+				void transition;
+
+				return React.createElement('div', divProps, children);
+			},
+			h1: ({ children, ...props }: ComponentProps<'h1'>) =>
+				React.createElement('h1', props, children),
+			button: ({ children, ...props }: ComponentProps<'button'>) =>
+				React.createElement('button', props, children),
+		},
+	};
+});
+
+const mockGetCourses = vi.mocked(courseService.getCourses);
+const mockShowToast = vi.mocked(showToast);
+
+const mockMatchMedia = () => {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	});
+};
+
+describe('LandingPage API error toast integration (#495)', () => {
+	beforeEach(() => {
+		mockMatchMedia();
+		window.localStorage.clear();
+		window.sessionStorage.clear();
+		mockGetCourses.mockReset();
+		vi.clearAllMocks();
+	});
+
+	it('shows a readable error toast and a nonblank fallback state when creator fetch fails', async () => {
+		mockGetCourses.mockRejectedValue(
+			new Error('Request failed with status 500')
+		);
+		render(
+			<MemoryRouter>
+				<LandingPage />
+			</MemoryRouter>
+		);
+
+		await waitFor(() => expect(mockShowToast.error).toHaveBeenCalledTimes(1));
+		expect(mockShowToast.error).toHaveBeenCalledWith(
+			'Unable to load creators. Check your connection and try again.'
+		);
+		expect(mockShowToast.error.mock.calls[0]?.[0]).not.toContain(
+			'[object Object]'
+		);
+		expect(
+			await screen.findByText(/loading live creators/i)
+		).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /try again/i })).toBeEnabled();
+	});
+});

--- a/src/pages/__tests__/LandingPage.priceFilters.integration.test.tsx
+++ b/src/pages/__tests__/LandingPage.priceFilters.integration.test.tsx
@@ -1,0 +1,146 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import LandingPage from '@/pages/LandingPage';
+import { courseService, type Course } from '@/services/course.service';
+
+vi.mock('@/services/course.service', () => ({
+	courseService: { getCourses: vi.fn() },
+}));
+
+vi.mock('@/hooks/useNetworkMismatch', () => ({
+	useNetworkMismatch: () => ({
+		isMismatch: false,
+		expectedChainName: 'Stellar Testnet',
+	}),
+}));
+
+vi.mock('@/hooks/useStaleData', () => ({
+	useStaleData: () => ({
+		stale: false,
+		ageMs: 0,
+		msUntilStale: 60_000,
+		revalidate: vi.fn(),
+	}),
+}));
+
+vi.mock('@/components/common/StellarConnectionQualityBadge', async () => {
+	const React = await import('react');
+
+	return {
+		default: () => React.createElement('div', { role: 'status' }, 'RPC good'),
+	};
+});
+
+vi.mock('@/components/common/CreatorCard', async () => {
+	const React = await import('react');
+
+	return {
+		default: ({ creator }: { creator: { title: string } }) =>
+			React.createElement(
+				'article',
+				{ 'aria-label': `Creator ${creator.title}` },
+				creator.title
+			),
+	};
+});
+
+vi.mock('framer-motion', async () => {
+	const React = await import('react');
+	type MotionDivProps = ComponentProps<'div'> & {
+		layout?: boolean;
+		transition?: unknown;
+	};
+
+	return {
+		AnimatePresence: ({ children }: { children: ReactNode }) =>
+			React.createElement(React.Fragment, null, children),
+		LayoutGroup: ({ children }: { children: ReactNode }) =>
+			React.createElement(React.Fragment, null, children),
+		motion: {
+			div: ({ children, ...props }: MotionDivProps) => {
+				const { layout, transition, ...divProps } = props;
+				void layout;
+				void transition;
+
+				return React.createElement('div', divProps, children);
+			},
+			h1: ({ children, ...props }: ComponentProps<'h1'>) =>
+				React.createElement('h1', props, children),
+			button: ({ children, ...props }: ComponentProps<'button'>) =>
+				React.createElement('button', props, children),
+		},
+	};
+});
+
+const mockGetCourses = vi.mocked(courseService.getCourses);
+
+const creator: Course = {
+	id: '1',
+	title: 'Creator Alpha',
+	description: 'Digital artist',
+	price: 0.05,
+	priceStroops: 500_000,
+	creatorShareSupply: 100,
+	instructorId: 'creator-a',
+	category: 'Art',
+	level: 'BEGINNER',
+	isVerified: true,
+};
+
+const mockMatchMedia = () => {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	});
+};
+
+describe('LandingPage price filters integration (#493)', () => {
+	beforeEach(() => {
+		mockMatchMedia();
+		window.localStorage.clear();
+		window.sessionStorage.clear();
+		mockGetCourses.mockReset();
+	});
+
+	it('clears min and max price inputs and re-fetches creators without price params', async () => {
+		mockGetCourses.mockResolvedValue([creator]);
+		render(
+			<MemoryRouter>
+				<LandingPage />
+			</MemoryRouter>
+		);
+		await waitFor(() => expect(mockGetCourses).toHaveBeenCalledTimes(1));
+
+		const minPriceInput = screen.getByLabelText(/min price/i);
+		const maxPriceInput = screen.getByLabelText(/max price/i);
+
+		fireEvent.change(minPriceInput, { target: { value: '1.5' } });
+		fireEvent.change(maxPriceInput, { target: { value: '4.25' } });
+
+		await waitFor(() =>
+			expect(mockGetCourses).toHaveBeenLastCalledWith({
+				min_price: 1.5,
+				max_price: 4.25,
+			})
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: /^clear$/i }));
+
+		await waitFor(() => {
+			expect(minPriceInput).toHaveValue(null);
+			expect(maxPriceInput).toHaveValue(null);
+			expect(mockGetCourses).toHaveBeenLastCalledWith(undefined);
+		});
+	});
+});

--- a/src/services/course.service.ts
+++ b/src/services/course.service.ts
@@ -30,6 +30,8 @@ export interface GetCoursesParams {
 	limit?: number;
 	category?: string;
 	search?: string;
+	min_price?: number;
+	max_price?: number;
 }
 
 class CourseService extends BaseApiService {

--- a/src/utils/__tests__/creatorListKey.utils.test.ts
+++ b/src/utils/__tests__/creatorListKey.utils.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { creatorListKey } from '@/utils/creatorListKey.utils';
+
+describe('creatorListKey', () => {
+	it.each([
+		[1, 'creator-1'],
+		[42, 'creator-42'],
+		[9_999, 'creator-9999'],
+	])('returns a stable creator key for creator id %i', (creatorId, key) => {
+		expect(creatorListKey(creatorId)).toBe(key);
+	});
+});

--- a/src/utils/creatorListKey.utils.ts
+++ b/src/utils/creatorListKey.utils.ts
@@ -1,0 +1,2 @@
+export const creatorListKey = (creatorId: number): string =>
+	`creator-${creatorId}`;


### PR DESCRIPTION
## Summary
- Add `creatorListKey(creatorId)` and use it for creator card list keys.
- Add min/max price filters with clear behavior that re-fetches the unfiltered creator list.
- Show a readable error toast plus an inline fallback notice when creator list loading fails.
- Document shared hook folder conventions, naming, and test expectations.

## Tests
- `pnpm vitest run src/utils/__tests__/creatorListKey.utils.test.ts src/pages/__tests__/LandingPage.priceFilters.integration.test.tsx src/pages/__tests__/LandingPage.apiErrorToast.integration.test.tsx`
- `pnpm build`
- `pnpm lint` (passes with existing `CreatorCard.tsx` exhaustive-deps warning)

## Notes
- Full `pnpm test` currently has unrelated existing failures in `LandingPage.keyboard.test.tsx`, `ConnectWalletButton.test.tsx`, and `TradeDialog` tests; the focused tests for this PR pass.

Closes #492.
Closes #493.
Closes #494.
Closes #495.
