### PR TITLE
test: add clipboard and sort-order preference integration tests

### DIFF
--- a/src/components/common/__tests__/CopyField.test.tsx
+++ b/src/components/common/__tests__/CopyField.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import CopyField from '@/components/common/CopyField';
+
+vi.mock('@/utils/toast.util', () => ({
+	default: { success: vi.fn() },
+}));
+
+const FULL_ADDRESS = 'GBUKOFF6RS5OTIHMGMH4MOVKPAS4JJIZGYXS4DOVZDNBH5YXKJXFNEC';
+
+function setupClipboard() {
+	const writeText = vi.fn().mockResolvedValue(undefined);
+	Object.defineProperty(navigator, 'clipboard', {
+		value: { writeText },
+		configurable: true,
+		writable: true,
+	});
+	return { writeText };
+}
+
+describe('CopyField clipboard integration', () => {
+	beforeEach(() => {
+		setupClipboard();
+	});
+
+	it('copies the full unmasked address to clipboard on button click', async () => {
+		const { writeText } = setupClipboard();
+		const user = userEvent.setup();
+
+		render(<CopyField value={FULL_ADDRESS} label="Wallet address" />);
+
+		const copyBtn = screen.getByRole('button', { name: /copy wallet address/i });
+		await user.click(copyBtn);
+
+		expect(writeText).toHaveBeenCalledOnce();
+		expect(writeText).toHaveBeenCalledWith(FULL_ADDRESS);
+	});
+
+	it('displays the full address in the input field', () => {
+		render(<CopyField value={FULL_ADDRESS} label="Wallet address" />);
+
+		const input = screen.getByRole('textbox', { name: /wallet address/i });
+		expect(input).toHaveValue(FULL_ADDRESS);
+	});
+
+	it('shows copied state after clicking copy', async () => {
+		setupClipboard();
+		const user = userEvent.setup();
+
+		render(<CopyField value={FULL_ADDRESS} label="Wallet address" />);
+
+		await user.click(screen.getByRole('button', { name: /copy wallet address/i }));
+
+		expect(screen.getByRole('button', { name: /wallet address copied/i })).toBeInTheDocument();
+	});
+});

--- a/src/utils/__tests__/preferences.sortOrder.test.ts
+++ b/src/utils/__tests__/preferences.sortOrder.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getPreference, setPreference } from '../preferences.utils';
+
+const SORT_KEY = 'creator-list-sort-order';
+const DEFAULT_SORT = 'asc';
+
+describe('sort order persistence via preferences.utils', () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
+
+	it('persists the selected sort order across simulated remounts', () => {
+		setPreference(SORT_KEY, 'desc');
+
+		// Simulate component unmount/remount: re-read from storage with no in-memory state
+		const restored = getPreference(SORT_KEY, DEFAULT_SORT);
+		expect(restored).toBe('desc');
+	});
+
+	it('returns the default sort order when storage is cleared', () => {
+		setPreference(SORT_KEY, 'desc');
+		window.localStorage.clear();
+
+		const restored = getPreference(SORT_KEY, DEFAULT_SORT);
+		expect(restored).toBe(DEFAULT_SORT);
+	});
+
+	it('persists across multiple sort order changes', () => {
+		const orders = ['desc', 'asc', 'desc'] as const;
+		for (const order of orders) {
+			setPreference(SORT_KEY, order);
+			expect(getPreference(SORT_KEY, DEFAULT_SORT)).toBe(order);
+		}
+	});
+
+	it('isolates sort order per key — changing one key does not affect another', () => {
+		setPreference('sort-a', 'desc');
+		setPreference('sort-b', 'asc');
+
+		expect(getPreference('sort-a', DEFAULT_SORT)).toBe('desc');
+		expect(getPreference('sort-b', DEFAULT_SORT)).toBe('asc');
+	});
+});


### PR DESCRIPTION
## Summary

- **#476 — CopyField clipboard test**: renders `CopyField`, mocks `navigator.clipboard.writeText`, clicks the copy button, and asserts the full unmasked Stellar address (not a shortened form) is passed to the clipboard. Also verifies the copied-state `aria-label` update.

- **#478 — Sort order persistence**: tests that `setPreference`/`getPreference` preserve a user's chosen sort order across simulated remounts, correctly reset to the default when `localStorage` is cleared, survive multiple toggles, and are isolated per storage key.

## Test plan

- [ ] `src/components/common/__tests__/CopyField.test.tsx` — 3 tests
- [ ] `src/utils/__tests__/preferences.sortOrder.test.ts` — 4 tests

Closes accesslayerorg/accesslayer-client#476
Closes accesslayerorg/accesslayer-client#478