### PR TITLE
Add integration test for localStorage preference helper persisting sort order across re-renders

### DIFF
--- a/src/utils/__tests__/preferences.sort.integration.test.ts
+++ b/src/utils/__tests__/preferences.sort.integration.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getPreference, setPreference } from '../preferences.utils';
+
+const SORT_KEY = 'creator-list:sort-order';
+type SortOrder = 'asc' | 'desc';
+const DEFAULT_SORT: SortOrder = 'asc';
+
+/**
+ * Simulates an unmount + remount cycle by clearing and re-reading from localStorage,
+ * mirroring what happens when a component that calls getPreference re-renders fresh.
+ */
+function remount(key: string, defaultValue: SortOrder): SortOrder {
+	return getPreference<SortOrder>(key, defaultValue);
+}
+
+describe('preferences — sort order persistence across re-renders', () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
+
+	it('reads back the saved sort preference after remount', () => {
+		setPreference<SortOrder>(SORT_KEY, 'desc');
+
+		const restored = remount(SORT_KEY, DEFAULT_SORT);
+
+		expect(restored).toBe('desc');
+	});
+
+	it('applies the default sort when no preference is stored', () => {
+		const restored = remount(SORT_KEY, DEFAULT_SORT);
+
+		expect(restored).toBe(DEFAULT_SORT);
+	});
+
+	it('overwriting a preference is reflected on the next remount', () => {
+		setPreference<SortOrder>(SORT_KEY, 'desc');
+		setPreference<SortOrder>(SORT_KEY, 'asc');
+
+		const restored = remount(SORT_KEY, DEFAULT_SORT);
+
+		expect(restored).toBe('asc');
+	});
+
+	it('clearing storage resets to the default sort on remount', () => {
+		setPreference<SortOrder>(SORT_KEY, 'desc');
+
+		window.localStorage.clear();
+
+		const restored = remount(SORT_KEY, DEFAULT_SORT);
+
+		expect(restored).toBe(DEFAULT_SORT);
+	});
+
+	it('persists sort preference alongside unrelated keys without interference', () => {
+		setPreference('other-key', { theme: 'dark' });
+		setPreference<SortOrder>(SORT_KEY, 'desc');
+		setPreference('another-key', 42);
+
+		const restored = remount(SORT_KEY, DEFAULT_SORT);
+
+		expect(restored).toBe('desc');
+	});
+});


### PR DESCRIPTION
## Summary

Adds an integration test suite for `setPreference`/`getPreference` verifying that sort order preferences survive a simulated unmount/remount cycle.

## Changes

- `src/utils/__tests__/preferences.sort.integration.test.ts` — new integration tests
  - Saved `desc` sort is read back after remount
  - Default `asc` applied when no preference stored
  - Overwriting a preference reflects the new value on next read
  - Clearing storage resets to default
  - Sort key is isolated from unrelated localStorage entries

Closes #478