### PR TITLE
test: add PriceSparkline component and unit tests for data point rendering

### DIFF
--- a/src/components/common/PriceSparkline.tsx
+++ b/src/components/common/PriceSparkline.tsx
@@ -1,0 +1,83 @@
+import { cn } from '@/lib/utils';
+
+interface PriceSparklineProps {
+	dataPoints: number[];
+	width?: number;
+	height?: number;
+	className?: string;
+}
+
+const POSITIVE_COLOR = '#34d399';
+const NEUTRAL_COLOR = 'currentColor';
+
+export function PriceSparkline({
+	dataPoints,
+	width = 120,
+	height = 40,
+	className,
+}: PriceSparklineProps) {
+	if (dataPoints.length === 0) return null;
+
+	const lineColor =
+		dataPoints.length >= 2 && dataPoints[dataPoints.length - 1] > dataPoints[0]
+			? POSITIVE_COLOR
+			: NEUTRAL_COLOR;
+
+	const padding = 2;
+	const innerWidth = width - padding * 2;
+	const innerHeight = height - padding * 2;
+
+	if (dataPoints.length === 1) {
+		return (
+			<svg
+				width={width}
+				height={height}
+				viewBox={`0 0 ${width} ${height}`}
+				className={cn('overflow-visible', className)}
+				role="img"
+				aria-label="Price sparkline"
+			>
+				<circle
+					cx={width / 2}
+					cy={height / 2}
+					r={2}
+					fill={lineColor}
+				/>
+			</svg>
+		);
+	}
+
+	const min = Math.min(...dataPoints);
+	const max = Math.max(...dataPoints);
+	const range = max - min || 1;
+
+	const buildPathD = () =>
+		dataPoints
+			.map((value, index) => {
+				const x = padding + (index / (dataPoints.length - 1)) * innerWidth;
+				const y =
+					padding + (1 - (value - min) / range) * innerHeight;
+				return `${index === 0 ? 'M' : 'L'}${x.toFixed(1)} ${y.toFixed(1)}`;
+			})
+			.join(' ');
+
+	return (
+		<svg
+			width={width}
+			height={height}
+			viewBox={`0 0 ${width} ${height}`}
+			className={cn('overflow-visible', className)}
+			role="img"
+			aria-label="Price sparkline"
+		>
+			<path
+				d={buildPathD()}
+				fill="none"
+				stroke={lineColor}
+				strokeWidth={1.5}
+				strokeLinecap="round"
+				strokeLinejoin="round"
+			/>
+		</svg>
+	);
+}

--- a/src/components/common/__tests__/PriceSparkline.test.tsx
+++ b/src/components/common/__tests__/PriceSparkline.test.tsx
@@ -1,0 +1,49 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { PriceSparkline } from '../PriceSparkline';
+
+describe('PriceSparkline', () => {
+	it('renders an SVG path for 7 data points', () => {
+		const { container } = render(
+			<PriceSparkline
+				dataPoints={[10, 20, 15, 25, 30, 22, 35]}
+			/>
+		);
+
+		const svg = container.querySelector('svg');
+		expect(svg).toBeInTheDocument();
+
+		const path = container.querySelector('path');
+		expect(path).toBeInTheDocument();
+		expect(path).toHaveAttribute('d');
+	});
+
+	it('renders without error for 1 data point and does not produce a line path', () => {
+		const { container } = render(
+			<PriceSparkline dataPoints={[42]} />
+		);
+
+		const svg = container.querySelector('svg');
+		expect(svg).toBeInTheDocument();
+
+		const path = container.querySelector('path');
+		expect(path).not.toBeInTheDocument();
+	});
+
+	it('renders nothing for 0 data points', () => {
+		const { container } = render(
+			<PriceSparkline dataPoints={[]} />
+		);
+
+		expect(container.innerHTML).toBe('');
+	});
+
+	it('applies green line colour when the last value is higher than the first', () => {
+		const { container } = render(
+			<PriceSparkline dataPoints={[10, 20, 30]} />
+		);
+
+		const path = container.querySelector('path');
+		expect(path).toHaveAttribute('stroke', '#34d399');
+	});
+});


### PR DESCRIPTION
## Summary

Adds the missing `PriceSparkline` SVG component and comprehensive unit tests for rendering the correct number of data points, edge cases, and line color.

## What changed

- **`src/components/common/PriceSparkline.tsx`** — New component that accepts a `dataPoints: number[]` prop and renders an SVG `<path>` polyline. Handles 7+ points (full line), 1 point (circle dot, no path), and 0 points (returns null).
- **`src/components/common/__tests__/PriceSparkline.test.tsx`** — Co-located tests covering all acceptance criteria.

## Key design decisions

- Component is **standalone** and agnostic about data source — accepts `dataPoints` directly rather than coupling to the `Course` model (which has no `priceHistory` field). Integration into `CreatorCard` is a follow-up.
- Uses `emerald-400` (`#34d399`) for the positive line color, matching the design system already used in `RecentActivityBadge`, `Change24hBadge`, etc.
- For 0 data points → returns `null` so callers see nothing. For 1 data point → renders an SVG with a dot (no line path), which satisfies "no error" without visual breakage.

## Acceptance criteria checklist

- [x] 7 data points produce a rendered `<path>` element
- [x] 1 data point renders without throwing (no line path, dot only)
- [x] 0 data points renders nothing (empty container)
- [x] Green line colour (`#34d399`) applied when last value > first value

## Test output

```
✓ src/components/common/__tests__/PriceSparkline.test.tsx (4 tests) 79ms
  Tests  4 passed (4)
```

## Follow-ups

- Wire `PriceSparkline` into `CreatorCard.tsx` when the API provides `priceHistory` data
- Add a red/rose line color for negative trends (not in scope of this issue)

## Security note

No secrets, user input, or auth tokens are involved. The component only renders static SVG from numeric data.

Closes #572