### PR TITLE
Add Navigation Timing Performance Logging for Client-Side Route Loads

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,14 @@ import Lenis from 'lenis';
 import { useEffect } from 'react';
 import { Toaster } from 'react-hot-toast';
 import { createBrowserRouter, RouterProvider } from 'react-router';
+import { useNavigationTiming } from './hooks/useNavigationTiming';
 import { routes } from './routes';
 
 const router = createBrowserRouter(routes);
 
 function App() {
+	useNavigationTiming();
+
 	useEffect(() => {
 		const lenis = new Lenis({
 			duration: 1.2,

--- a/src/hooks/useNavigationTiming.ts
+++ b/src/hooks/useNavigationTiming.ts
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router';
+
+interface NavigationTiming {
+	route: string;
+	dom_content_loaded_ms: number;
+	load_event_ms: number;
+	time_to_first_byte_ms: number;
+}
+
+function readNavigationTiming(): {
+	timing: NavigationTiming;
+	startTime: number;
+} | null {
+	const entries = performance.getEntriesByType('navigation');
+	if (!entries.length) return null;
+
+	const nav = entries[0] as PerformanceNavigationTiming;
+
+	return {
+		timing: {
+			route: window.location.pathname,
+			dom_content_loaded_ms: Math.round(
+				nav.domContentLoadedEventEnd - nav.startTime
+			),
+			load_event_ms: Math.round(nav.loadEventEnd - nav.startTime),
+			time_to_first_byte_ms: Math.round(
+				nav.responseStart - nav.requestStart
+			),
+		},
+		startTime: nav.startTime,
+	};
+}
+
+export function useNavigationTiming() {
+	const location = useLocation();
+	const loggedStartTime = useRef<number | null>(null);
+
+	useEffect(() => {
+		function emit() {
+			const result = readNavigationTiming();
+			if (!result) return;
+			if (loggedStartTime.current === result.startTime) return;
+
+			loggedStartTime.current = result.startTime;
+			console.debug('[navigation-timing]', result.timing);
+		}
+
+		if (document.readyState === 'complete') {
+			emit();
+		} else {
+			window.addEventListener('load', emit, { once: true });
+			return () => window.removeEventListener('load', emit);
+		}
+	}, [location]);
+}


### PR DESCRIPTION
##closed #575

Implement client-side page load performance logging using the Navigation Timing API to provide visibility into route load times across the application. This feature will emit structured debug-level logs after each full page load, enabling production logs to identify slow-loading routes and support performance monitoring.

The implementation should read the PerformanceNavigationTiming entry after the page's load event has completed and emit a structured log containing the following fields:
    route
    dom_content_loaded_ms
    load_event_ms
    time_to_first_byte_ms

Logging should occur only after the load event has fully completed, ensuring that timing metrics are complete and accurate. If navigation timing data is unavailable for a route, the logger should skip emitting a log without producing errors or warnings.

Acceptance Criteria
    Emit a debug-level log after each full page load.
    Include the fields: route, dom_content_loaded_ms, load_event_ms, and time_to_first_byte_ms.
    Do not emit logs before the page load event completes.
    Silently skip logging when PerformanceNavigationTiming data is unavailable