### PR TITLE
implemented

### DIFF
--- a/src/hooks/__tests__/useInfiniteScroll.test.tsx
+++ b/src/hooks/__tests__/useInfiniteScroll.test.tsx
@@ -1,0 +1,99 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
+
+const observers: {
+	callback: IntersectionObserverCallback;
+	observe: ReturnType<typeof vi.fn>;
+	disconnect: ReturnType<typeof vi.fn>;
+}[] = [];
+
+beforeEach(() => {
+	observers.length = 0;
+
+	class MockIntersectionObserver {
+		callback: IntersectionObserverCallback;
+		observe = vi.fn();
+		disconnect = vi.fn();
+		unobserve = vi.fn();
+		constructor(cb: IntersectionObserverCallback) {
+			this.callback = cb;
+			observers.push({
+				callback: cb,
+				observe: this.observe,
+				disconnect: this.disconnect,
+			});
+		}
+	}
+
+	vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function simulateIntersection(isIntersecting: boolean) {
+	const obs = observers[observers.length - 1];
+	act(() => {
+		obs.callback(
+			[{ isIntersecting } as IntersectionObserverEntry],
+			{} as IntersectionObserver,
+		);
+	});
+}
+
+function TestComponent({
+	enabled,
+	hasMore,
+	onLoadMore,
+}: {
+	enabled: boolean;
+	hasMore: boolean;
+	onLoadMore: () => void;
+}) {
+	const sentinelRef = useInfiniteScroll<HTMLDivElement>({ enabled, hasMore, onLoadMore });
+	return <div data-testid="sentinel" ref={sentinelRef} />;
+}
+
+describe('useInfiniteScroll', () => {
+	it('calls onLoadMore when the observed element intersects', () => {
+		const onLoadMore = vi.fn();
+		render(<TestComponent enabled={true} hasMore={true} onLoadMore={onLoadMore} />);
+
+		simulateIntersection(true);
+
+		expect(onLoadMore).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not call onLoadMore when the element is not intersecting', () => {
+		const onLoadMore = vi.fn();
+		render(<TestComponent enabled={true} hasMore={true} onLoadMore={onLoadMore} />);
+
+		simulateIntersection(false);
+
+		expect(onLoadMore).not.toHaveBeenCalled();
+	});
+
+	it('disconnects the observer on unmount', () => {
+		const { unmount } = render(
+			<TestComponent enabled={true} hasMore={true} onLoadMore={vi.fn()} />,
+		);
+
+		unmount();
+
+		expect(observers[0].disconnect).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not create an observer when enabled is false', () => {
+		render(<TestComponent enabled={false} hasMore={true} onLoadMore={vi.fn()} />);
+
+		expect(observers).toHaveLength(0);
+	});
+
+	it('does not create an observer when hasMore is false', () => {
+		render(<TestComponent enabled={true} hasMore={false} onLoadMore={vi.fn()} />);
+
+		expect(observers).toHaveLength(0);
+	});
+});


### PR DESCRIPTION
## Summary

**File**: `src/hooks/__tests__/useInfiniteScroll.test.tsx`

**Tests:**
1. **Callback fires on intersection** — confirms `onLoadMore` is called when the sentinel element intersects
2. **Callback does not fire when not intersecting** — confirms `onLoadMore` is NOT called when the element is out of view
3. **Observer disconnected on unmount** — confirms `disconnect()` is called when the component unmounts
4. **Observer not created when `enabled: false`** — confirms no observer is created when the hook is disabled
5. **Observer not created when `hasMore: false`** — bonus: also covers the `hasMore` guard

The mock uses a class-based `IntersectionObserver` replacement that captures callbacks, allowing tests to manually simulate intersection events. The root cause of the initial failures was a JSX gotcha: bare attribute shorthand `onLoadMore` was interpreted as `onLoadMore={true}`, which broke the ref.
-

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm build`

## Checklist

- [ ] Linked issue or backlog item
- [ ] Scope is limited to the stated change
- [ ] Updated docs if behavior or setup changed
- [ ] Added screenshots for UI changes when relevant
Closes #586
Closes #587
Closes #588
Closes #589
