### PR TITLE
test: add useRelativeTime hook and unit tests (#597)

### DIFF
--- a/src/hooks/__tests__/useRelativeTime.test.ts
+++ b/src/hooks/__tests__/useRelativeTime.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useRelativeTime } from '@/hooks/useRelativeTime';
+
+describe('useRelativeTime', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-07-26T12:00:00Z'));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('returns a seconds-relative string for a timestamp 30 seconds ago', () => {
+		const { result } = renderHook(() =>
+			useRelativeTime(new Date(Date.now() - 30_000))
+		);
+		expect(result.current).toMatch(/just now/i);
+	});
+
+	it('returns a minutes-relative string for a timestamp 90 seconds ago', () => {
+		const { result } = renderHook(() =>
+			useRelativeTime(new Date(Date.now() - 90_000))
+		);
+		expect(result.current).toMatch(/minute/i);
+	});
+
+	it('returns an hours-relative string for a timestamp 2 hours ago', () => {
+		const { result } = renderHook(() =>
+			useRelativeTime(new Date(Date.now() - 2 * 60 * 60 * 1000))
+		);
+		expect(result.current).toMatch(/hour/i);
+	});
+
+	it('returns a days-relative string for a timestamp 3 days ago', () => {
+		const { result } = renderHook(() =>
+			useRelativeTime(new Date(Date.now() - 3 * 24 * 60 * 60 * 1000))
+		);
+		expect(result.current).toMatch(/day/i);
+	});
+
+	it('updates the output after the 60-second refresh interval', () => {
+		const base = Date.now();
+		const { result } = renderHook(() =>
+			useRelativeTime(new Date(base - 30_000))
+		);
+
+		expect(result.current).toMatch(/just now/i);
+
+		act(() => {
+			vi.setSystemTime(new Date(base + 60_000));
+			vi.advanceTimersByTime(60_000);
+		});
+
+		expect(result.current).toMatch(/minute/i);
+	});
+
+	it('returns N/A for a null timestamp', () => {
+		const { result } = renderHook(() => useRelativeTime(null));
+		expect(result.current).toBe('N/A');
+	});
+
+	it('returns N/A for an undefined timestamp', () => {
+		const { result } = renderHook(() => useRelativeTime(undefined));
+		expect(result.current).toBe('N/A');
+	});
+
+	it('returns N/A for an invalid date string', () => {
+		const { result } = renderHook(() => useRelativeTime('not-a-date'));
+		expect(result.current).toBe('N/A');
+	});
+
+	it('cleans up the interval on unmount', () => {
+		const clearIntervalSpy = vi.spyOn(window, 'clearInterval');
+		const { unmount } = renderHook(() =>
+			useRelativeTime(new Date(Date.now() - 60_000))
+		);
+		unmount();
+		expect(clearIntervalSpy).toHaveBeenCalled();
+		clearIntervalSpy.mockRestore();
+	});
+});

--- a/src/hooks/useRelativeTime.ts
+++ b/src/hooks/useRelativeTime.ts
@@ -1,0 +1,30 @@
+import { useEffect, useMemo, useState } from 'react';
+import { formatRelativeTimeLabel } from '@/utils/time.utils';
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+/**
+ * Returns a human-readable relative-time label for the given timestamp,
+ * automatically refreshing every 60 seconds so the display stays current.
+ */
+export function useRelativeTime(
+	timestamp: string | number | Date | null | undefined
+): string {
+	const date = useMemo(() => {
+		if (timestamp == null) return null;
+		const d = timestamp instanceof Date ? timestamp : new Date(timestamp);
+		return Number.isNaN(d.getTime()) ? null : d;
+	}, [timestamp]);
+
+	const [now, setNow] = useState(() => new Date());
+
+	useEffect(() => {
+		if (date == null) return;
+		const id = window.setInterval(() => setNow(new Date()), REFRESH_INTERVAL_MS);
+		return () => window.clearInterval(id);
+	}, [date]);
+
+	if (date == null) return 'N/A';
+
+	return formatRelativeTimeLabel(date, now);
+}


### PR DESCRIPTION


---
Closes #597
## Summary
Add the `useRelativeTime` hook and comprehensive unit tests for issue #597.

## Changes
- **`src/hooks/useRelativeTime.ts`** — New hook that returns a human-readable relative-time label for a given timestamp, auto-refreshing every 60 seconds via `setInterval`. Delegates formatting to the existing `formatRelativeTimeLabel` utility.
- **`src/hooks/__tests__/useRelativeTime.test.ts`** — 9 unit tests covering all acceptance criteria.

## Tests
- 30 seconds ago → returns seconds-relative string (`just now`)
- 90 seconds ago → returns minutes-relative string
- 2 hours ago → returns hours-relative string
- 3 days ago → returns days-relative string
- Output updates after 60-second timer interval
- Returns `N/A` for null, undefined, and invalid timestamps
- Cleans up the interval on unmount

Closes #597