### PR TITLE
feat(formatting): centralise XLM and relative-time formatting in shared hooks

### DIFF
--- a/src/components/common/TransactionHistory.tsx
+++ b/src/components/common/TransactionHistory.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { ChevronDown, ChevronUp, ArrowUpRight, ArrowDownRight, Minus } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useFormatXlm, useRelativeTime } from '@/hooks/formatting';
 
 interface Transaction {
 	id: string;
@@ -69,17 +70,150 @@ const SAMPLE_TRANSACTIONS: Transaction[] = [
 	},
 ];
 
-const formatTimestamp = (timestamp: number) => {
-	const now = Date.now();
-	const diff = now - timestamp;
-	const minutes = Math.floor(diff / (1000 * 60));
-	const hours = Math.floor(diff / (1000 * 60 * 60));
-	const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+const getTransactionIcon = (type: Transaction['type']) => {
+	switch (type) {
+		case 'buy':
+			return <ArrowUpRight className="size-4 text-emerald-400" />;
+		case 'sell':
+			return <ArrowDownRight className="size-4 text-rose-400" />;
+		default:
+			return <Minus className="size-4 text-white/40" />;
+	}
+};
 
-	if (minutes < 1) return 'Just now';
-	if (minutes < 60) return `${minutes}m ago`;
-	if (hours < 24) return `${hours}h ago`;
-	return `${days}d ago`;
+const getTransactionTypeLabel = (type: Transaction['type']) => {
+	switch (type) {
+		case 'buy':
+			return 'Buy';
+		case 'sell':
+			return 'Sell';
+		default:
+			return 'Unknown';
+	}
+};
+
+interface TransactionRowProps {
+	tx: Transaction;
+	isCompact: boolean;
+	isExpanded: boolean;
+	onToggleExpansion: (id: string) => void;
+}
+
+const TransactionRow: React.FC<TransactionRowProps> = ({
+	tx,
+	isCompact,
+	isExpanded,
+	onToggleExpansion,
+}) => {
+	const relativeTime = useRelativeTime(tx.timestamp);
+	const totalAmount = useFormatXlm(tx.amount * tx.price, 4);
+
+	return (
+		<div
+			className={cn(
+				'group rounded-xl border border-white/10 bg-white/[0.02] transition-all duration-200 hover:border-white/20 hover:bg-white/[0.04]',
+				isCompact && !isExpanded && 'py-2',
+				(!isCompact || isExpanded) && 'p-4'
+			)}
+		>
+			<div className="flex items-center gap-4">
+				<div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-white/5">
+					{getTransactionIcon(tx.type)}
+				</div>
+
+				<div className="flex min-w-0 flex-1 items-center gap-4">
+					<div className="min-w-0 flex-1">
+						<div className="flex items-center gap-2">
+							<span className="font-semibold text-white">
+								{getTransactionTypeLabel(tx.type)}
+							</span>
+							<span className="text-white/40">•</span>
+							<span className="text-white/90">{tx.creator}</span>
+						</div>
+						{(!isCompact || isExpanded) && (
+							<div className="mt-1 flex items-center gap-3 text-xs text-white/50">
+								<span>{tx.amount} keys</span>
+								<span className="text-white/30">•</span>
+								<span>{tx.price} ETH</span>
+								<span className="text-white/30">•</span>
+								<span>{relativeTime}</span>
+							</div>
+						)}
+					</div>
+
+					{(!isCompact || isExpanded) && (
+						<div className="hidden shrink-0 items-center gap-4 text-right sm:flex">
+							<div className="text-sm">
+								<div className="font-semibold text-white">
+									{tx.type === 'buy' ? '+' : '-'}
+									{totalAmount} ETH
+								</div>
+								<div className="text-xs text-white/50">
+									{tx.txHash}
+								</div>
+							</div>
+							<div className="flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1">
+								<div className="size-1.5 rounded-full bg-emerald-400" />
+								<span className="text-xs font-semibold text-emerald-400">
+									{tx.status}
+								</span>
+							</div>
+						</div>
+					)}
+
+					{isCompact && !isExpanded && (
+						<div className="flex shrink-0 items-center gap-3">
+							<div className="text-right">
+								<div className="text-sm font-semibold text-white">
+									{tx.type === 'buy' ? '+' : '-'}
+									{totalAmount} ETH
+								</div>
+							</div>
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={() => onToggleExpansion(tx.id)}
+								className="h-8 w-8 rounded-lg p-0 text-white/50 hover:bg-white/10 hover:text-white"
+							>
+								<ChevronDown className="size-4" />
+							</Button>
+						</div>
+					)}
+
+					{isCompact && isExpanded && (
+						<Button
+							variant="ghost"
+							size="sm"
+							onClick={() => onToggleExpansion(tx.id)}
+							className="h-8 w-8 rounded-lg p-0 text-white/50 hover:bg-white/10 hover:text-white"
+						>
+							<ChevronUp className="size-4" />
+						</Button>
+					)}
+				</div>
+			</div>
+
+			{isCompact && isExpanded && (
+				<div className="mt-3 flex items-center justify-between border-t border-white/10 pt-3 text-xs">
+					<div className="flex items-center gap-3 text-white/50">
+						<span>{tx.amount} keys</span>
+						<span className="text-white/30">•</span>
+						<span>{tx.price} ETH</span>
+						<span className="text-white/30">•</span>
+						<span>{relativeTime}</span>
+						<span className="text-white/30">•</span>
+						<span>{tx.txHash}</span>
+					</div>
+					<div className="flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1">
+						<div className="size-1.5 rounded-full bg-emerald-400" />
+						<span className="text-xs font-semibold text-emerald-400">
+							{tx.status}
+						</span>
+					</div>
+				</div>
+			)}
+		</div>
+	);
 };
 
 const TransactionHistory: React.FC = () => {
@@ -110,28 +244,6 @@ const TransactionHistory: React.FC = () => {
 		});
 	};
 
-	const getTransactionIcon = (type: Transaction['type']) => {
-		switch (type) {
-			case 'buy':
-				return <ArrowUpRight className="size-4 text-emerald-400" />;
-			case 'sell':
-				return <ArrowDownRight className="size-4 text-rose-400" />;
-			default:
-				return <Minus className="size-4 text-white/40" />;
-		}
-	};
-
-	const getTransactionTypeLabel = (type: Transaction['type']) => {
-		switch (type) {
-			case 'buy':
-				return 'Buy';
-			case 'sell':
-				return 'Sell';
-			default:
-				return 'Unknown';
-		}
-	};
-
 	return (
 		<section className="rounded-2xl border border-white/10 bg-white/5 p-6 md:p-8">
 			<div className="mb-6 flex items-center justify-between">
@@ -154,116 +266,15 @@ const TransactionHistory: React.FC = () => {
 			</div>
 
 			<div className="space-y-2">
-				{SAMPLE_TRANSACTIONS.map(tx => {
-					const isExpanded = expandedRows.has(tx.id) || !isCompact;
-					return (
-						<div
-							key={tx.id}
-							className={cn(
-								'group rounded-xl border border-white/10 bg-white/[0.02] transition-all duration-200 hover:border-white/20 hover:bg-white/[0.04]',
-								isCompact && !isExpanded && 'py-2',
-								(!isCompact || isExpanded) && 'p-4'
-							)}
-						>
-							<div className="flex items-center gap-4">
-								<div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-white/5">
-									{getTransactionIcon(tx.type)}
-								</div>
-								
-								<div className="flex min-w-0 flex-1 items-center gap-4">
-									<div className="min-w-0 flex-1">
-										<div className="flex items-center gap-2">
-											<span className="font-semibold text-white">
-												{getTransactionTypeLabel(tx.type)}
-											</span>
-											<span className="text-white/40">•</span>
-											<span className="text-white/90">{tx.creator}</span>
-										</div>
-										{(!isCompact || isExpanded) && (
-											<div className="mt-1 flex items-center gap-3 text-xs text-white/50">
-												<span>{tx.amount} keys</span>
-												<span className="text-white/30">•</span>
-												<span>{tx.price} ETH</span>
-												<span className="text-white/30">•</span>
-												<span>{formatTimestamp(tx.timestamp)}</span>
-											</div>
-										)}
-									</div>
-
-									{(!isCompact || isExpanded) && (
-										<div className="hidden shrink-0 items-center gap-4 text-right sm:flex">
-											<div className="text-sm">
-												<div className="font-semibold text-white">
-													{tx.type === 'buy' ? '+' : '-'}
-													{(tx.amount * tx.price).toFixed(4)} ETH
-												</div>
-												<div className="text-xs text-white/50">
-													{tx.txHash}
-												</div>
-											</div>
-											<div className="flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1">
-												<div className="size-1.5 rounded-full bg-emerald-400" />
-												<span className="text-xs font-semibold text-emerald-400">
-													{tx.status}
-												</span>
-											</div>
-										</div>
-									)}
-
-									{isCompact && !isExpanded && (
-										<div className="flex shrink-0 items-center gap-3">
-											<div className="text-right">
-												<div className="text-sm font-semibold text-white">
-													{tx.type === 'buy' ? '+' : '-'}
-													{(tx.amount * tx.price).toFixed(4)} ETH
-												</div>
-											</div>
-											<Button
-												variant="ghost"
-												size="sm"
-												onClick={() => toggleRowExpansion(tx.id)}
-												className="h-8 w-8 rounded-lg p-0 text-white/50 hover:bg-white/10 hover:text-white"
-											>
-												<ChevronDown className="size-4" />
-											</Button>
-										</div>
-									)}
-
-									{isCompact && isExpanded && (
-										<Button
-											variant="ghost"
-											size="sm"
-											onClick={() => toggleRowExpansion(tx.id)}
-											className="h-8 w-8 rounded-lg p-0 text-white/50 hover:bg-white/10 hover:text-white"
-										>
-											<ChevronUp className="size-4" />
-										</Button>
-									)}
-								</div>
-							</div>
-
-							{isCompact && isExpanded && (
-								<div className="mt-3 flex items-center justify-between border-t border-white/10 pt-3 text-xs">
-									<div className="flex items-center gap-3 text-white/50">
-										<span>{tx.amount} keys</span>
-										<span className="text-white/30">•</span>
-										<span>{tx.price} ETH</span>
-										<span className="text-white/30">•</span>
-										<span>{formatTimestamp(tx.timestamp)}</span>
-										<span className="text-white/30">•</span>
-										<span>{tx.txHash}</span>
-									</div>
-									<div className="flex items-center gap-1.5 rounded-full bg-emerald-500/10 px-2.5 py-1">
-										<div className="size-1.5 rounded-full bg-emerald-400" />
-										<span className="text-xs font-semibold text-emerald-400">
-											{tx.status}
-										</span>
-									</div>
-								</div>
-							)}
-						</div>
-					);
-				})}
+				{SAMPLE_TRANSACTIONS.map(tx => (
+					<TransactionRow
+						key={tx.id}
+						tx={tx}
+						isCompact={isCompact}
+						isExpanded={expandedRows.has(tx.id) || !isCompact}
+						onToggleExpansion={toggleRowExpansion}
+					/>
+				))}
 			</div>
 		</section>
 	);

--- a/src/components/home/TrendingCreatorCard.tsx
+++ b/src/components/home/TrendingCreatorCard.tsx
@@ -2,15 +2,22 @@ import makeBlockie from 'ethereum-blockies-base64';
 import { Users, ArrowRight } from 'lucide-react';
 import { Link } from 'react-router';
 import type { Course } from '@/services/course.service';
+import { useFormatXlm } from '@/hooks/formatting';
 
 type Props = { creator: Course & { walletAddress: string } };
 
 export default function TrendingCreatorCard({ creator }: Props) {
 	const name = creator.title || 'Unnamed creator';
 	const avatar = makeBlockie(creator.walletAddress);
-	const priceXlm = creator.priceStroops
-		? (creator.priceStroops / 1e7).toFixed(2)
-		: creator.price.toFixed(2);
+	// Raw stroops arrive as an integer count → pass as bigint so the hook applies
+	// the shared STROOPS_PER_XLM conversion; the legacy `price` field is already
+	// denominated in whole XLM and passes through as a number.
+	const priceXlm = useFormatXlm(
+		creator.priceStroops
+			? BigInt(Math.round(creator.priceStroops))
+			: creator.price,
+		2
+	);
 
 	return (
 		<article className="group relative overflow-hidden rounded-2xl border border-black/8 bg-white transition-all duration-300 hover:-translate-y-0.5">

--- a/src/hooks/__tests__/useFormatXlm.test.ts
+++ b/src/hooks/__tests__/useFormatXlm.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useFormatXlm } from '@/hooks/formatting';
+
+describe('useFormatXlm', () => {
+	it('defaults to 2 decimal places', () => {
+		const { result } = renderHook(() => useFormatXlm(12.5));
+		expect(result.current).toBe('12.50');
+	});
+
+	it('applies locale-aware thousands separators', () => {
+		const { result } = renderHook(() => useFormatXlm(1234567.891));
+		expect(result.current).toBe('1,234,567.89');
+	});
+
+	it('honours a configurable decimal override', () => {
+		const { result } = renderHook(() => useFormatXlm(0.25, 4));
+		expect(result.current).toBe('0.2500');
+	});
+
+	it('converts a bigint stroop amount to XLM using STROOPS_PER_XLM', () => {
+		// 25_000_000 stroops = 2.5 XLM (1 XLM = 10^7 stroops).
+		const { result } = renderHook(() => useFormatXlm(25_000_000n));
+		expect(result.current).toBe('2.50');
+	});
+
+	it('preserves fractional precision for large bigint stroop amounts', () => {
+		// 12_345_678_912_345 stroops = 1,234,567.8912345 XLM.
+		const { result } = renderHook(() =>
+			useFormatXlm(12_345_678_912_345n, 4)
+		);
+		expect(result.current).toBe('1,234,567.8912');
+	});
+
+	it('renders a placeholder for non-finite input', () => {
+		const { result } = renderHook(() => useFormatXlm(Number.NaN));
+		expect(result.current).toBe('—');
+	});
+});

--- a/src/hooks/__tests__/useRelativeTime.test.ts
+++ b/src/hooks/__tests__/useRelativeTime.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useRelativeTime } from '@/hooks/formatting';
+
+const MINUTE = 60 * 1000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+describe('useRelativeTime', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-07-26T00:00:00Z'));
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('renders a minute-granularity relative string', () => {
+		const { result } = renderHook(() =>
+			useRelativeTime(Date.now() - 2 * MINUTE)
+		);
+		expect(result.current).toBe('2 minutes ago');
+	});
+
+	it('renders an hour-granularity relative string', () => {
+		const { result } = renderHook(() =>
+			useRelativeTime(Date.now() - 3 * HOUR)
+		);
+		expect(result.current).toBe('3 hours ago');
+	});
+
+	it('renders a day-granularity relative string', () => {
+		const { result } = renderHook(() =>
+			useRelativeTime(Date.now() - (3 * DAY + MINUTE))
+		);
+		expect(result.current).toBe('3 days ago');
+	});
+
+	it('reports sub-minute timestamps as "now"', () => {
+		const { result } = renderHook(() =>
+			useRelativeTime(Date.now() - 30 * 1000)
+		);
+		expect(result.current).toBe('now');
+	});
+
+	it('refreshes the label every 60 seconds while mounted', () => {
+		// 2 minutes and 5 seconds ago → floors to "2 minutes ago".
+		const { result } = renderHook(() =>
+			useRelativeTime(Date.now() - (2 * MINUTE + 5 * 1000))
+		);
+		expect(result.current).toBe('2 minutes ago');
+
+		act(() => {
+			vi.advanceTimersByTime(60 * 1000);
+		});
+		expect(result.current).toBe('3 minutes ago');
+	});
+});

--- a/src/hooks/formatting/index.ts
+++ b/src/hooks/formatting/index.ts
@@ -1,0 +1,2 @@
+export { useFormatXlm } from './useFormatXlm';
+export { useRelativeTime } from './useRelativeTime';

--- a/src/hooks/formatting/useFormatXlm.ts
+++ b/src/hooks/formatting/useFormatXlm.ts
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import { STROOPS_PER_XLM } from '@/constants/stellar';
+
+/**
+ * Formats an XLM amount for display with locale-aware thousands separators and a
+ * configurable number of decimal places.
+ *
+ * Accepts either:
+ * - a `number`, treated as an already-denominated XLM value (e.g. `12.5` XLM), or
+ * - a `bigint`, treated as a raw stroop count and converted to XLM using the
+ *   same `STROOPS_PER_XLM` factor the rest of the codebase relies on
+ *   (see `keyPriceDisplay.utils.ts`). Using `bigint` division here preserves the
+ *   fractional part without the precision loss a naive `Number(amount)` would
+ *   introduce for large stroop values.
+ *
+ * The `'en-US'` locale is pinned deliberately so separator/precision output is
+ * deterministic across environments (matching the issue's stated example).
+ */
+export function useFormatXlm(amount: bigint | number, decimals = 2): string {
+	return useMemo(() => {
+		let xlm: number;
+
+		if (typeof amount === 'bigint') {
+			const perXlm = BigInt(STROOPS_PER_XLM);
+			const whole = amount / perXlm;
+			const fraction = amount % perXlm;
+			xlm = Number(whole) + Number(fraction) / STROOPS_PER_XLM;
+		} else {
+			xlm = amount;
+		}
+
+		if (!Number.isFinite(xlm)) return '—';
+
+		return new Intl.NumberFormat('en-US', {
+			minimumFractionDigits: decimals,
+			maximumFractionDigits: decimals,
+		}).format(xlm);
+	}, [amount, decimals]);
+}

--- a/src/hooks/formatting/useRelativeTime.ts
+++ b/src/hooks/formatting/useRelativeTime.ts
@@ -1,0 +1,50 @@
+import { useEffect, useMemo, useState } from 'react';
+
+/** Refresh cadence for the relative label while the component stays mounted. */
+const REFRESH_INTERVAL_MS = 60_000;
+
+const relativeFormatter = new Intl.RelativeTimeFormat('en-US', {
+	numeric: 'auto',
+});
+
+/**
+ * Produces a human-readable relative-time string ("2 minutes ago", "3 days
+ * ago") from a millisecond epoch timestamp using `Intl.RelativeTimeFormat`.
+ *
+ * The unit-selection thresholds intentionally mirror the previous hand-rolled
+ * logic in `TransactionHistory.tsx` (minutes < 60 → minutes, hours < 24 →
+ * hours, otherwise days) so the chosen granularity does not visibly change —
+ * only the formatting mechanism does.
+ */
+function formatRelative(timestamp: number, now: number): string {
+	const diff = now - timestamp;
+	const minutes = Math.floor(diff / (1000 * 60));
+	const hours = Math.floor(diff / (1000 * 60 * 60));
+	const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+	if (minutes < 1) return relativeFormatter.format(0, 'second');
+	if (minutes < 60) return relativeFormatter.format(-minutes, 'minute');
+	if (hours < 24) return relativeFormatter.format(-hours, 'hour');
+	return relativeFormatter.format(-days, 'day');
+}
+
+/**
+ * Returns a relative-time label for `timestamp` and re-renders the consuming
+ * component every 60 seconds so the label stays current while mounted. The
+ * interval is cleared on unmount / timestamp change (matching the cleanup
+ * convention in `useDropCountdown.ts`).
+ */
+export function useRelativeTime(timestamp: number): string {
+	const [now, setNow] = useState(() => Date.now());
+
+	useEffect(() => {
+		setNow(Date.now());
+		const id = window.setInterval(
+			() => setNow(Date.now()),
+			REFRESH_INTERVAL_MS
+		);
+		return () => window.clearInterval(id);
+	}, [timestamp]);
+
+	return useMemo(() => formatRelative(timestamp, now), [timestamp, now]);
+}


### PR DESCRIPTION
## Summary

New `src/hooks/formatting/` module (`useFormatXlm.ts`, `useRelativeTime.ts`):

- **`useFormatXlm(amount: bigint | number, decimals = 2)`** — `Intl.NumberFormat('en-US', {min/maxFractionDigits})`. A `number` is treated as an already-denominated XLM value; a `bigint` is treated as raw stroops and converted with whole/remainder bigint division against the existing `STROOPS_PER_XLM` constant (`src/constants/stellar.ts`, the same factor `keyPriceDisplay.utils.ts` already uses) to preserve fractional precision — no new conversion logic was written.
- **`useRelativeTime(timestamp)`** — `Intl.RelativeTimeFormat('en-US', {numeric: 'auto'})`, matching the same unit thresholds as the previous hand-rolled logic (minute/hour/day/"now"), with a 60-second `setInterval` re-render cleaned up on unmount (matching the `useDropCountdown.ts` convention).

**Call sites migrated:**
- `TransactionHistory.tsx` ("the activity feed") — replaced the hand-rolled relative-time formatting and two `(tx.amount * tx.price).toFixed(4)` calls. Rows are rendered via `.map()`, so a `TransactionRow` child component was extracted to call the hooks legally per row.
- `TrendingCreatorCard.tsx` — a genuine inline `(creator.priceStroops / 1e7).toFixed(2)` stroops→XLM display found via a repo-wide search, now routed through `useFormatXlm`.

**"Trade panel"/"holdings" finding:** there's no separate inline-formatted XLM amount to migrate there. `TradeDialog.tsx` already routes every XLM figure through the existing shared `formatDisplayKeyPrice` util, and its "Holdings: … keys" is a key *count* via `formatNumber`, not an XLM amount — so the only real migrations were `TransactionHistory` and `TrendingCreatorCard`.

Closes #547

## Pre-existing bug noticed, not fixed (out of scope)
`TransactionHistory.tsx` labels amounts "ETH" in this Stellar/XLM app. Left untouched per scope — worth its own issue.

## Test plan
- [ ] Could not run vitest locally (no `node_modules`, disk space constraint in my environment) — please run the new `useFormatXlm.test.ts`/`useRelativeTime.test.ts`
- [ ] Manually verify the activity feed and trending creator card still show correct amounts/timestamps, and that relative times advance after 60s without a page reload