### PR TITLE
feat: add toast component unit tests

### DIFF
--- a/src/utils/__tests__/toast.util.test.tsx
+++ b/src/utils/__tests__/toast.util.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen, act } from '@testing-library/react';
+import { Toaster } from 'react-hot-toast';
+import toast from 'react-hot-toast';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import showToast from '../toast.util';
+
+describe('toast util auto-dismiss and manual close', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		Object.defineProperty(window, 'matchMedia', {
+			writable: true,
+			value: vi.fn().mockImplementation((query: string) => ({
+				matches: false,
+				media: query,
+				onchange: null,
+				addEventListener: vi.fn(),
+				removeEventListener: vi.fn(),
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+				dispatchEvent: vi.fn(),
+			})),
+		});
+	});
+
+	afterEach(() => {
+		toast.remove();
+		vi.useRealTimers();
+	});
+
+	it('toast visible immediately after render', () => {
+		render(<Toaster />);
+
+		act(() => {
+			showToast.success('Success message');
+		});
+
+		expect(screen.getByText('Success message')).toBeInTheDocument();
+	});
+
+	it('toast still visible before auto-dismiss fires', () => {
+		render(<Toaster />);
+
+		act(() => {
+			showToast.success('Success message');
+		});
+
+		expect(screen.getByText('Success message')).toBeInTheDocument();
+
+		act(() => {
+			vi.advanceTimersByTime(3999);
+		});
+
+		expect(screen.getByText('Success message')).toBeInTheDocument();
+	});
+
+	it('toast removed after auto-dismiss and remove delay', () => {
+		render(<Toaster />);
+
+		act(() => {
+			showToast.success('Success message');
+		});
+
+		expect(screen.getByText('Success message')).toBeInTheDocument();
+
+		act(() => {
+			vi.advanceTimersByTime(4000);
+		});
+
+		act(() => {
+			vi.advanceTimersByTime(1000);
+		});
+
+		expect(screen.queryByText('Success message')).not.toBeInTheDocument();
+	});
+
+	it('manual close removes the toast before the auto-dismiss timer fires', () => {
+		render(<Toaster />);
+
+		act(() => {
+			showToast.success('Success message');
+		});
+
+		expect(screen.getByText('Success message')).toBeInTheDocument();
+
+		act(() => {
+			toast.dismiss();
+		});
+
+		act(() => {
+			vi.advanceTimersByTime(1000);
+		});
+
+		expect(screen.queryByText('Success message')).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Add unit tests for toast component auto-dismiss and manual close

### Summary
Added unit tests for `showToast.success()` confirming both the auto-dismiss timing and manual close behavior work correctly.

### Changes
- **New file:** `src/utils/__tests__/toast.util.test.tsx`

### Tests added
| Test | Assertion |
|------|-----------|
| Toast visible immediately after render | `getByText('Success message')` is in the document |
| Toast still visible at 3999ms | After `advanceTimersByTime(3999)`, toast remains in the DOM |
| Toast removed after auto-dismiss + remove delay | After advancing past 4000ms (dismiss) + 1000ms (`REMOVE_DELAY`), toast is removed from the DOM |
| Manual close removes toast before auto-dismiss | Calling `toast.dismiss()` removes the toast immediately without waiting for the timer |

### Notes
- Tests use `vi.useFakeTimers()` with a `matchMedia` mock required by `react-hot-toast`'s `<Toaster>` component
- The `<Toaster>` from `react-hot-toast` is rendered directly in tests (not the app's `<Toaster>` from `App.tsx`) to isolate the toast utility
- `react-hot-toast` uses a two-phase removal: dismiss (sets `visible: false`) then a `REMOVE_DELAY` of 1000ms before unmounting from the DOM


Closes #628 
