### PR TITLE
feat(observability): log successful wallet connections via useWalletConnectionLogger (#599)

### DIFF
--- a/src/hooks/__tests__/useWalletConnectionLogger.test.ts
+++ b/src/hooks/__tests__/useWalletConnectionLogger.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for the structured wallet-connection debug log (#599).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useAccount } from 'wagmi';
+import { useWalletConnectionLogger } from '@/hooks/useWalletConnectionLogger';
+
+vi.mock('wagmi', () => ({
+	useAccount: vi.fn(),
+}));
+
+const mockUseAccount = vi.mocked(useAccount);
+
+const FULL_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+const SECOND_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+
+function mockAccount(overrides: Partial<ReturnType<typeof useAccount>> = {}) {
+	mockUseAccount.mockReturnValue({
+		address: undefined,
+		isConnected: false,
+		connector: undefined,
+		...overrides,
+	} as ReturnType<typeof useAccount>);
+}
+
+describe('useWalletConnectionLogger (#599)', () => {
+	let debugSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+	});
+
+	it('emits a structured debug log with all three fields on a successful connection', () => {
+		mockAccount({
+			address: FULL_ADDRESS,
+			isConnected: true,
+			connector: { id: 'injected', name: 'MetaMask' } as ReturnType<
+				typeof useAccount
+			>['connector'],
+		});
+
+		renderHook(() => useWalletConnectionLogger({ isTestEnv: false }));
+
+		expect(debugSpy).toHaveBeenCalledTimes(1);
+		expect(debugSpy).toHaveBeenCalledWith(
+			'[wallet-connection]',
+			expect.objectContaining({
+				truncated_address: '0x12...5678',
+				connection_method: 'MetaMask',
+				connected_at: expect.stringMatching(
+					/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+				),
+			})
+		);
+	});
+
+	it('never includes the full wallet address under any field name', () => {
+		mockAccount({
+			address: FULL_ADDRESS,
+			isConnected: true,
+			connector: { id: 'injected', name: 'Injected' } as ReturnType<
+				typeof useAccount
+			>['connector'],
+		});
+
+		renderHook(() => useWalletConnectionLogger({ isTestEnv: false }));
+
+		const [, log] = debugSpy.mock.calls[0];
+		expect(JSON.stringify(log)).not.toContain(FULL_ADDRESS);
+	});
+
+	it('falls back to the connector id when no name is available', () => {
+		mockAccount({
+			address: FULL_ADDRESS,
+			isConnected: true,
+			connector: { id: 'albedo' } as ReturnType<typeof useAccount>['connector'],
+		});
+
+		renderHook(() => useWalletConnectionLogger({ isTestEnv: false }));
+
+		expect(debugSpy).toHaveBeenCalledWith(
+			'[wallet-connection]',
+			expect.objectContaining({ connection_method: 'albedo' })
+		);
+	});
+
+	it('falls back to "unknown" when there is no connector at all', () => {
+		mockAccount({ address: FULL_ADDRESS, isConnected: true, connector: undefined });
+
+		renderHook(() => useWalletConnectionLogger({ isTestEnv: false }));
+
+		expect(debugSpy).toHaveBeenCalledWith(
+			'[wallet-connection]',
+			expect.objectContaining({ connection_method: 'unknown' })
+		);
+	});
+
+	it('does not emit when the wallet is not connected', () => {
+		mockAccount({ address: undefined, isConnected: false });
+
+		renderHook(() => useWalletConnectionLogger({ isTestEnv: false }));
+
+		expect(debugSpy).not.toHaveBeenCalled();
+	});
+
+	it('does not re-emit on re-renders for the same connected address', () => {
+		mockAccount({
+			address: FULL_ADDRESS,
+			isConnected: true,
+			connector: { id: 'injected', name: 'Injected' } as ReturnType<
+				typeof useAccount
+			>['connector'],
+		});
+
+		const { rerender } = renderHook(() =>
+			useWalletConnectionLogger({ isTestEnv: false })
+		);
+		rerender();
+		rerender();
+
+		expect(debugSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('emits again after a disconnect/reconnect cycle', () => {
+		mockAccount({
+			address: FULL_ADDRESS,
+			isConnected: true,
+			connector: { id: 'injected', name: 'Injected' } as ReturnType<
+				typeof useAccount
+			>['connector'],
+		});
+		const { rerender } = renderHook(() =>
+			useWalletConnectionLogger({ isTestEnv: false })
+		);
+		expect(debugSpy).toHaveBeenCalledTimes(1);
+
+		mockAccount({ address: undefined, isConnected: false });
+		rerender();
+		expect(debugSpy).toHaveBeenCalledTimes(1);
+
+		mockAccount({
+			address: SECOND_ADDRESS,
+			isConnected: true,
+			connector: { id: 'injected', name: 'Injected' } as ReturnType<
+				typeof useAccount
+			>['connector'],
+		});
+		rerender();
+		expect(debugSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not emit in the test environment by default', () => {
+		mockAccount({
+			address: FULL_ADDRESS,
+			isConnected: true,
+			connector: { id: 'injected', name: 'Injected' } as ReturnType<
+				typeof useAccount
+			>['connector'],
+		});
+
+		renderHook(() => useWalletConnectionLogger());
+
+		expect(debugSpy).not.toHaveBeenCalled();
+	});
+});

--- a/src/hooks/useWalletConnectionLogger.ts
+++ b/src/hooks/useWalletConnectionLogger.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+import { useAccount } from 'wagmi';
+import { shortenAddress } from '@/lib/web3/format';
+
+export interface WalletConnectionLog {
+	truncated_address: string;
+	connection_method: string;
+	connected_at: string;
+}
+
+interface UseWalletConnectionLoggerOptions {
+	/**
+	 * Suppresses log emission when true. Defaults to detecting the Vitest
+	 * runner via `process.env.NODE_ENV`; injectable so the hook itself can be
+	 * tested.
+	 */
+	isTestEnv?: boolean;
+}
+
+/**
+ * Emits a debug-level structured log the moment a wallet connection
+ * succeeds, so developers can trace wallet session activity without relying
+ * on browser extension logs.
+ *
+ * Dedupes on the connected address: the log fires once per distinct
+ * connection, not on every re-render and not again for unrelated state or
+ * query cache updates that leave the address unchanged. Disconnecting resets
+ * the dedupe key, so a later reconnection (same or different address) logs
+ * again.
+ *
+ * The full wallet address is never logged — only the truncated form
+ * (first 4 + last 4 characters).
+ */
+export function useWalletConnectionLogger({
+	isTestEnv = process.env.NODE_ENV === 'test',
+}: UseWalletConnectionLoggerOptions = {}): void {
+	const { address, isConnected, connector } = useAccount();
+	const loggedAddressRef = useRef<string | undefined>(undefined);
+
+	useEffect(() => {
+		if (!isConnected || !address) {
+			loggedAddressRef.current = undefined;
+			return;
+		}
+
+		if (loggedAddressRef.current === address) {
+			return;
+		}
+		loggedAddressRef.current = address;
+
+		if (isTestEnv) return;
+
+		const log: WalletConnectionLog = {
+			truncated_address: shortenAddress(address),
+			connection_method: connector?.name ?? connector?.id ?? 'unknown',
+			connected_at: new Date().toISOString(),
+		};
+
+		console.debug('[wallet-connection]', log);
+	}, [address, isConnected, connector, isTestEnv]);
+}

--- a/src/providers/Web3Provider.tsx
+++ b/src/providers/Web3Provider.tsx
@@ -2,16 +2,28 @@ import type { ReactNode } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { WagmiProvider } from 'wagmi';
 import { wagmiConfig } from '@/lib/web3/wagmiConfig';
+import { useWalletConnectionLogger } from '@/hooks/useWalletConnectionLogger';
 import { queryClient } from './web3Utils';
 
 interface Web3ProviderProps {
   children: ReactNode;
 }
 
+/**
+ * Mounted once at the Web3 provider boundary so wallet connections are
+ * logged exactly once app-wide, regardless of which UI (connect button,
+ * reconnect banner, etc.) initiated the connection.
+ */
+function WalletConnectionLogger() {
+  useWalletConnectionLogger();
+  return null;
+}
+
 export default function Web3Provider({ children }: Web3ProviderProps) {
   return (
     <WagmiProvider config={wagmiConfig}>
       <QueryClientProvider client={queryClient}>
+        <WalletConnectionLogger />
         {children}
       </QueryClientProvider>
     </WagmiProvider>


### PR DESCRIPTION
Closes #599

## Summary

Adds a debug-level structured log emitted the moment a wallet connection succeeds, so developers can trace wallet session activity without relying on browser extension logs.

## What was implemented

- **`useWalletConnectionLogger`** (`src/hooks/useWalletConnectionLogger.ts`): a hook that watches wagmi's `useAccount()` state and, on a successful connection, emits:
  ```
  console.debug('[wallet-connection]', {
    truncated_address, // first 4 + last 4 chars, e.g. "0x12...5678"
    connection_method, // active connector's name (falls back to id, then "unknown")
    connected_at,       // ISO timestamp
  });
  ```
  - Dedupes on the connected address via a `useRef`, so the log fires **once per connection event** — not on re-renders, and not again for unrelated state or query-cache updates that leave the address unchanged.
  - Disconnecting resets the dedupe key, so a later reconnection (same or different address) logs again.
  - Suppressed by default when `process.env.NODE_ENV === 'test'`, matching the existing `[cache-invalidation]` logging convention in `useWallet.ts`.
  - The full wallet address is never included under any field name — only the truncated form, reused from the existing `shortenAddress` util (`src/lib/web3/format.ts`).

- **`Web3Provider`** (`src/providers/Web3Provider.tsx`): mounts a small internal `WalletConnectionLogger` component (calls the hook, renders `null`) inside the provider tree, so the log fires exactly once app-wide regardless of which UI — `ConnectWalletButton` or `WalletConnectCalloutBanner` — initiated the connection, rather than duplicating the logic in each.

## Files

**New files**
- `src/hooks/useWalletConnectionLogger.ts` — the logging hook
- `src/hooks/__tests__/useWalletConnectionLogger.test.ts` — unit tests

**Modified files**
- `src/providers/Web3Provider.tsx` — mounts the logger once at the provider boundary

## Tests added

`src/hooks/__tests__/useWalletConnectionLogger.test.ts` (mocks `wagmi`'s `useAccount`, matching the pattern used in `useNetworkMismatch.test.ts`):

- Emits a structured log with `truncated_address`, `connection_method`, and `connected_at` on a successful connection
- Never includes the full wallet address under any field name
- Falls back to the connector `id` when no `name` is available
- Falls back to `"unknown"` when there is no connector at all
- Does not emit when the wallet is not connected
- Does not re-emit on re-renders for the same connected address
- Emits again after a disconnect/reconnect cycle
- Does not emit in the test environment by default

## How to test

```bash
pnpm test src/hooks/__tests__/useWalletConnectionLogger.test.ts
```

Manually: connect a wallet via `ConnectWalletButton` in a non-test build and confirm the browser console prints a single `[wallet-connection]` debug log with a truncated address, the connector name, and a timestamp — and that navigating/re-rendering afterward does not print it again.
