### PR TITLE
test: add copy confirmation timing tests for CopyField (#600)

### DIFF
--- a/src/components/common/__tests__/CopyField.test.tsx
+++ b/src/components/common/__tests__/CopyField.test.tsx
@@ -1,41 +1,40 @@
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import CopyField from '@/components/common/CopyField';
+import { copyTextToClipboard } from '@/utils/clipboard.utils';
 
 vi.mock('@/utils/toast.util', () => ({
-	default: { success: vi.fn() },
+	default: { success: vi.fn(), error: vi.fn() },
 }));
 
-const FULL_ADDRESS = 'GBUKOFF6RS5OTIHMGMH4MOVKPAS4JJIZGYXS4DOVZDNBH5YXKJXFNEC';
+vi.mock('@/utils/clipboard.utils', () => ({
+	copyTextToClipboard: vi.fn().mockResolvedValue(undefined),
+}));
 
-function setupClipboard() {
-	const writeText = vi.fn().mockResolvedValue(undefined);
-	Object.defineProperty(navigator, 'clipboard', {
-		value: { writeText },
-		configurable: true,
-		writable: true,
-	});
-	return { writeText };
-}
+const mockCopyTextToClipboard = vi.mocked(copyTextToClipboard);
+
+const FULL_ADDRESS =
+	'GBUKOFF6RS5OTIHMGMH4MOVKPAS4JJIZGYXS4DOVZDNBH5YXKJXFNEC';
 
 describe('CopyField clipboard integration', () => {
 	beforeEach(() => {
-		setupClipboard();
+		vi.clearAllMocks();
 	});
 
 	it('copies the full unmasked address to clipboard on button click', async () => {
-		const { writeText } = setupClipboard();
 		const user = userEvent.setup();
 
 		render(<CopyField value={FULL_ADDRESS} label="Wallet address" />);
 
-		const copyBtn = screen.getByRole('button', { name: /copy wallet address/i });
+		const copyBtn = screen.getByRole('button', {
+			name: /copy wallet address/i,
+		});
 		await user.click(copyBtn);
 
-		expect(writeText).toHaveBeenCalledOnce();
-		expect(writeText).toHaveBeenCalledWith(FULL_ADDRESS);
+		expect(mockCopyTextToClipboard).toHaveBeenCalledOnce();
+		expect(mockCopyTextToClipboard).toHaveBeenCalledWith(FULL_ADDRESS);
 	});
 
 	it('displays the full address in the input field', () => {
@@ -46,13 +45,115 @@ describe('CopyField clipboard integration', () => {
 	});
 
 	it('shows copied state after clicking copy', async () => {
-		setupClipboard();
 		const user = userEvent.setup();
 
 		render(<CopyField value={FULL_ADDRESS} label="Wallet address" />);
 
-		await user.click(screen.getByRole('button', { name: /copy wallet address/i }));
+		await user.click(
+			screen.getByRole('button', { name: /copy wallet address/i })
+		);
 
-		expect(screen.getByRole('button', { name: /wallet address copied/i })).toBeInTheDocument();
+		expect(
+			screen.getByRole('button', { name: /wallet address copied/i })
+		).toBeInTheDocument();
+	});
+});
+
+describe('CopyField copy confirmation timing (#600)', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('shows Copied confirmation immediately after click', async () => {
+		render(<CopyField value={FULL_ADDRESS} label="Wallet address" />);
+
+		await act(async () => {
+			fireEvent.click(
+				screen.getByRole('button', { name: /copy wallet address/i })
+			);
+		});
+
+		expect(
+			screen.getByRole('button', { name: /wallet address copied/i })
+		).toBeInTheDocument();
+	});
+
+	it('keeps Copied confirmation visible at 1999ms', async () => {
+		render(<CopyField value={FULL_ADDRESS} label="Wallet address" />);
+
+		await act(async () => {
+			fireEvent.click(
+				screen.getByRole('button', { name: /copy wallet address/i })
+			);
+		});
+
+		act(() => {
+			vi.advanceTimersByTime(1999);
+		});
+
+		expect(
+			screen.getByRole('button', { name: /wallet address copied/i })
+		).toBeInTheDocument();
+	});
+
+	it('reverts button to icon state at 2000ms', async () => {
+		render(<CopyField value={FULL_ADDRESS} label="Wallet address" />);
+
+		await act(async () => {
+			fireEvent.click(
+				screen.getByRole('button', { name: /copy wallet address/i })
+			);
+		});
+
+		act(() => {
+			vi.advanceTimersByTime(2000);
+		});
+
+		expect(
+			screen.getByRole('button', { name: /copy wallet address/i })
+		).toBeInTheDocument();
+		expect(
+			screen.queryByRole('button', { name: /wallet address copied/i })
+		).not.toBeInTheDocument();
+	});
+
+	it('resets confirmation on second click after timeout', async () => {
+		render(<CopyField value={FULL_ADDRESS} label="Wallet address" />);
+
+		// First click — confirmation appears
+		await act(async () => {
+			fireEvent.click(
+				screen.getByRole('button', { name: /copy wallet address/i })
+			);
+		});
+
+		expect(
+			screen.getByRole('button', { name: /wallet address copied/i })
+		).toBeInTheDocument();
+
+		// Advance past the 2000ms timeout so the button reverts
+		act(() => {
+			vi.advanceTimersByTime(2000);
+		});
+
+		expect(
+			screen.getByRole('button', { name: /copy wallet address/i })
+		).toBeInTheDocument();
+
+		// Second click — confirmation resets and appears again
+		await act(async () => {
+			fireEvent.click(
+				screen.getByRole('button', { name: /copy wallet address/i })
+			);
+		});
+
+		expect(
+			screen.getByRole('button', { name: /wallet address copied/i })
+		).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary

Adds unit tests for the copy-to-clipboard button in CopyField verifying that the Copied confirmation correctly resets after 2 seconds.

## Acceptance criteria covered

- **shows Copied confirmation immediately after click** — the check icon appears and aria-label updates to "{label} copied"
- **keeps Copied confirmation visible at 1999ms** — advancing fake timers by 1999ms still shows the copied state
- **reverts button to icon state at 2000ms** — at exactly 2000ms the button reverts, with a negative assertion confirming the copied label is no longer present
- **resets confirmation on second click after timeout** — after the 2-second reset, clicking again re-shows the confirmation

## Additional fix

Replaced the fragile navigator.clipboard Object.defineProperty mock with a module-level mock of @/utils/clipboard.utils using vi.mocked(). This avoids jsdom inconsistencies where navigator.clipboard is a getter-only property and cannot be reliably redefined across test runs.

## Testing approach

- Uses vi.useFakeTimers + fireEvent.click + await act(async () => {}) to flush clipboard promise microtasks, matching the established pattern from TransactionHashRow.test.tsx and ConnectWalletButton.test.tsx
- All 7 tests pass (pnpm vitest run src/components/common/__tests__/CopyField.test.tsx)
- ESLint: clean (0 errors, 0 warnings)
- TypeScript: tsc -b passes

## Files changed

- src/components/common/__tests__/CopyField.test.tsx — added 4 timing tests, fixed clipboard mocking approach

Closes #600