### PR TITLE
test(wallet): cover creator 404, activity ordering, holdings total updates, and disconnect session logging

### DIFF
--- a/src/components/common/ConnectWalletButton.tsx
+++ b/src/components/common/ConnectWalletButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAccount, useConnect, useDisconnect } from 'wagmi';
 import { Copy, Check } from 'lucide-react';
 import {
@@ -21,10 +21,12 @@ import { useCopySuccessAnnouncement } from '@/hooks/useCopySuccessAnnouncement';
 import CopySuccessAnnouncement from '@/components/common/CopySuccessAnnouncement';
 import showToast from '@/utils/toast.util';
 import { copyTextToClipboard } from '@/utils/clipboard.utils';
+import { logWalletDisconnectSession } from '@/lib/walletSessionLog';
 
 function ConnectWalletButton() {
 	const [showDisconnectDialog, setShowDisconnectDialog] = useState(false);
 	const [copied, setCopied] = useState(false);
+	const connectedAtRef = useRef<number | null>(null);
 	const { address, isConnected } = useAccount();
 	const { connect, connectors, error, isPending } = useConnect();
 	const { disconnect } = useDisconnect();
@@ -50,6 +52,17 @@ function ConnectWalletButton() {
 			);
 		}
 	};
+
+	useEffect(() => {
+		if (isConnected && address && connectedAtRef.current == null) {
+			connectedAtRef.current = Date.now();
+			return;
+		}
+
+		if (!isConnected) {
+			connectedAtRef.current = null;
+		}
+	}, [address, isConnected]);
 
 	if (isConnected && address) {
 		return (
@@ -84,7 +97,14 @@ function ConnectWalletButton() {
 									type="button"
 									variant="destructive"
 									onClick={() => {
+										if (connectedAtRef.current != null) {
+											logWalletDisconnectSession(
+												address,
+												connectedAtRef.current
+											);
+										}
 										disconnect();
+										connectedAtRef.current = null;
 										setShowDisconnectDialog(false);
 									}}
 								>

--- a/src/components/common/CreatorPageErrorBoundary.tsx
+++ b/src/components/common/CreatorPageErrorBoundary.tsx
@@ -2,6 +2,7 @@ import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { Link } from 'react-router';
 import { AlertCircle, ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { ApiError } from '@/services/api.service';
 
 interface Props {
 	children: ReactNode;
@@ -9,6 +10,7 @@ interface Props {
 
 interface State {
 	hasError: boolean;
+	error: Error | null;
 }
 
 /**
@@ -19,10 +21,11 @@ interface State {
 class CreatorPageErrorBoundary extends Component<Props, State> {
 	public state: State = {
 		hasError: false,
+		error: null,
 	};
 
-	public static getDerivedStateFromError(): State {
-		return { hasError: true };
+	public static getDerivedStateFromError(error: Error): State {
+		return { hasError: true, error };
 	}
 
 	public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
@@ -33,6 +36,10 @@ class CreatorPageErrorBoundary extends Component<Props, State> {
 
 	public render() {
 		if (this.state.hasError) {
+			const isNotFound =
+				this.state.error instanceof ApiError &&
+				this.state.error.status === 404;
+
 			return (
 				<main
 					className="flex min-h-screen flex-col items-center justify-center gap-6 bg-[#06111f] px-6 py-16 text-center text-white"
@@ -42,11 +49,14 @@ class CreatorPageErrorBoundary extends Component<Props, State> {
 					<div className="flex flex-col items-center gap-3">
 						<AlertCircle className="size-10 text-amber-400" aria-hidden="true" />
 						<h1 className="font-grotesque text-3xl font-black tracking-tight sm:text-4xl">
-							This creator page could not load
+							{isNotFound
+								? 'Creator not found'
+								: 'This creator page could not load'}
 						</h1>
 						<p className="max-w-md font-jakarta text-base leading-7 text-white/70">
-							Something went wrong while loading this creator. The rest of the
-							marketplace is still available.
+							{isNotFound
+								? "We couldn't find a creator with that ID. Return to the creator list to keep browsing."
+								: 'Something went wrong while loading this creator. The rest of the marketplace is still available.'}
 						</p>
 					</div>
 					<Button

--- a/src/components/common/TransactionHistory.tsx
+++ b/src/components/common/TransactionHistory.tsx
@@ -97,6 +97,14 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
 		localStorage.setItem(COMPACT_VIEW_KEY, String(isCompact));
 	}, [isCompact]);
 
+	const sortedTransactions = [...transactions].sort((left, right) => {
+		if (left.timestamp !== right.timestamp) {
+			return right.timestamp - left.timestamp;
+		}
+
+		return right.id.localeCompare(left.id);
+	});
+
 	const toggleCompact = () => {
 		setIsCompact(!isCompact);
 	};
@@ -157,7 +165,7 @@ const TransactionHistory: React.FC<TransactionHistoryProps> = ({
 			</div>
 
 			<div className="space-y-2">
-				{transactions.map(tx => {
+				{sortedTransactions.map(tx => {
 					const displayHandle = formatCreatorHandle(tx.creatorHandle);
 					const isExpanded = expandedRows.has(tx.id) || !isCompact;
 					return (

--- a/src/components/common/__tests__/ConnectWalletButton.test.tsx
+++ b/src/components/common/__tests__/ConnectWalletButton.test.tsx
@@ -15,6 +15,7 @@ const mockUseConnect = vi.mocked(useConnect);
 const mockUseDisconnect = vi.mocked(useDisconnect);
 
 const FULL_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+const TRUNCATED_ADDRESS_PATTERN = /0x12.*5678/i;
 
 function setupConnectedWalletMocks(disconnect = vi.fn()) {
 	mockUseAccount.mockReturnValue({
@@ -44,7 +45,9 @@ describe('ConnectWalletButton wallet disconnect confirmation', () => {
 	it('opens a confirmation dialog before disconnecting', () => {
 		const { disconnect } = renderConnectedWallet();
 
-		fireEvent.click(screen.getByRole('button', { name: /0x1234/i }));
+		fireEvent.click(
+			screen.getByRole('button', { name: TRUNCATED_ADDRESS_PATTERN })
+		);
 
 		expect(
 			screen.getByRole('dialog', { name: /disconnect wallet/i })
@@ -55,16 +58,50 @@ describe('ConnectWalletButton wallet disconnect confirmation', () => {
 	it('disconnects when the confirmation action is clicked', () => {
 		const { disconnect } = renderConnectedWallet();
 
-		fireEvent.click(screen.getByRole('button', { name: /0x1234/i }));
+		fireEvent.click(
+			screen.getByRole('button', { name: TRUNCATED_ADDRESS_PATTERN })
+		);
 		fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
 
 		expect(disconnect).toHaveBeenCalledTimes(1);
 	});
 
+	it('emits a structured disconnect log with session duration outside test env', () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-07-27T10:00:00.000Z'));
+		const originalEnv = process.env.NODE_ENV;
+		process.env.NODE_ENV = 'development';
+		const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+		const { disconnect } = renderConnectedWallet();
+
+		act(() => {
+			vi.advanceTimersByTime(4_500);
+		});
+
+		fireEvent.click(
+			screen.getByRole('button', { name: TRUNCATED_ADDRESS_PATTERN })
+		);
+		fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
+
+		expect(disconnect).toHaveBeenCalledTimes(1);
+		expect(debugSpy).toHaveBeenCalledWith('[wallet-disconnect]', {
+			truncated_address: '0x12...5678',
+			session_duration_ms: 4_500,
+			disconnected_at: '2026-07-27T10:00:04.500Z',
+		});
+		expect(JSON.stringify(debugSpy.mock.calls[0][1])).not.toContain(FULL_ADDRESS);
+
+		debugSpy.mockRestore();
+		process.env.NODE_ENV = originalEnv;
+		vi.useRealTimers();
+	});
+
 	it('cancels without disconnecting', async () => {
 		const { disconnect } = renderConnectedWallet();
 
-		fireEvent.click(screen.getByRole('button', { name: /0x1234/i }));
+		fireEvent.click(
+			screen.getByRole('button', { name: TRUNCATED_ADDRESS_PATTERN })
+		);
 		fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
 
 		await waitFor(() => {
@@ -76,7 +113,9 @@ describe('ConnectWalletButton wallet disconnect confirmation', () => {
 	it('dismisses with Escape without disconnecting', async () => {
 		const { disconnect } = renderConnectedWallet();
 
-		fireEvent.click(screen.getByRole('button', { name: /0x1234/i }));
+		fireEvent.click(
+			screen.getByRole('button', { name: TRUNCATED_ADDRESS_PATTERN })
+		);
 		fireEvent.keyDown(document, { key: 'Escape' });
 
 		await waitFor(() => {

--- a/src/components/common/__tests__/TransactionHistory.order.integration.test.tsx
+++ b/src/components/common/__tests__/TransactionHistory.order.integration.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import TransactionHistory, {
+	type Transaction,
+} from '@/components/common/TransactionHistory';
+
+const trades: Transaction[] = [
+	{
+		id: 'ledger-1000',
+		type: 'buy',
+		creatorId: 'creator-c',
+		creatorHandle: 'nova',
+		amount: 1,
+		price: 8,
+		timestamp: 1_000,
+		txHash: '0xccc',
+		status: 'completed',
+	},
+	{
+		id: 'ledger-3000',
+		type: 'buy',
+		creatorId: 'creator-a',
+		creatorHandle: 'atlas',
+		amount: 5,
+		price: 12,
+		timestamp: 3_000,
+		txHash: '0xaaa',
+		status: 'completed',
+	},
+	{
+		id: 'ledger-2000',
+		type: 'sell',
+		creatorId: 'creator-b',
+		creatorHandle: 'beacon',
+		amount: 2,
+		price: 10,
+		timestamp: 2_000,
+		txHash: '0xbbb',
+		status: 'completed',
+	},
+];
+
+beforeEach(() => {
+	vi.stubEnv('NODE_ENV', 'test');
+	localStorage.clear();
+});
+
+describe('TransactionHistory – wallet activity order and type labels (integration)', () => {
+	it('renders trades in descending chronological order with correct buy and sell labels', () => {
+		render(<TransactionHistory transactions={trades} />);
+
+		const rows = screen
+			.getAllByTestId(/activity-item-/)
+			.map(row => row.textContent ?? '');
+
+		expect(rows).toHaveLength(3);
+		expect(rows[0]).toContain('@atlas');
+		expect(rows[1]).toContain('@beacon');
+		expect(rows[2]).toContain('@nova');
+
+		const buyRows = screen.getAllByTestId('activity-item-buy');
+		const sellRows = screen.getAllByTestId('activity-item-sell');
+
+		expect(within(buyRows[0]).getByText('Buy')).toBeInTheDocument();
+		expect(within(buyRows[1]).getByText('Buy')).toBeInTheDocument();
+		expect(within(sellRows[0]).getByText('Sell')).toBeInTheDocument();
+		expect(buyRows).toHaveLength(2);
+		expect(sellRows).toHaveLength(1);
+		expect(rows[0]).toContain('5 keys');
+		expect(rows[1]).toContain('2 keys');
+		expect(rows[2]).toContain('1 keys');
+	});
+});

--- a/src/lib/__tests__/walletSessionLog.test.ts
+++ b/src/lib/__tests__/walletSessionLog.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	createWalletDisconnectLog,
+	logWalletDisconnectSession,
+} from '@/lib/walletSessionLog';
+
+describe('walletSessionLog', () => {
+	it('builds a structured disconnect log with a truncated address and session duration', () => {
+		const address = '0x1234567890abcdef1234567890abcdef12345678';
+		const connectedAt = 1_000;
+		const disconnectedAt = 4_250;
+
+		expect(
+			createWalletDisconnectLog(address, connectedAt, disconnectedAt)
+		).toEqual({
+			truncated_address: '0x12...5678',
+			session_duration_ms: 3_250,
+			disconnected_at: '1970-01-01T00:00:04.250Z',
+		});
+	});
+
+	it('does not emit a disconnect log in the test environment', () => {
+		const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+		logWalletDisconnectSession(
+			'0x1234567890abcdef1234567890abcdef12345678',
+			1_000,
+			2_000
+		);
+
+		expect(debugSpy).not.toHaveBeenCalled();
+		debugSpy.mockRestore();
+	});
+});

--- a/src/lib/walletSessionLog.ts
+++ b/src/lib/walletSessionLog.ts
@@ -1,0 +1,34 @@
+import { shortenAddress } from '@/lib/web3/format';
+
+export interface WalletDisconnectLogEntry {
+	truncated_address: string;
+	session_duration_ms: number;
+	disconnected_at: string;
+}
+
+export function createWalletDisconnectLog(
+	address: string,
+	connectedAt: number,
+	disconnectedAt: number = Date.now()
+): WalletDisconnectLogEntry {
+	return {
+		truncated_address: shortenAddress(address),
+		session_duration_ms: Math.max(0, disconnectedAt - connectedAt),
+		disconnected_at: new Date(disconnectedAt).toISOString(),
+	};
+}
+
+export function logWalletDisconnectSession(
+	address: string,
+	connectedAt: number,
+	disconnectedAt: number = Date.now()
+) {
+	if (process.env.NODE_ENV === 'test') {
+		return;
+	}
+
+	console.debug(
+		'[wallet-disconnect]',
+		createWalletDisconnectLog(address, connectedAt, disconnectedAt)
+	);
+}

--- a/src/pages/CreatorDetailPage.tsx
+++ b/src/pages/CreatorDetailPage.tsx
@@ -6,6 +6,7 @@ import CreatorProfileInfoGrid from '@/components/common/CreatorProfileInfoGrid';
 import { CreatorProfileHeaderSkeleton } from '@/components/common/CreatorSkeleton';
 import { bpsToPercent } from '@/utils/numberFormat.utils';
 import CreatorPageErrorBoundary from '@/components/common/CreatorPageErrorBoundary';
+import { ApiError } from '@/services/api.service';
 
 function CreatorDetailPageContent() {
 	const { id } = useParams<{ id: string }>();
@@ -21,8 +22,12 @@ function CreatorDetailPageContent() {
 		);
 	}
 
-	if (error || !creator) {
-		throw new Error('Creator not found');
+	if (error) {
+		throw error;
+	}
+
+	if (!creator) {
+		throw new ApiError('Creator not found', 404);
 	}
 
 	const feeItems = [

--- a/src/pages/__tests__/CreatorDetailPage.integration.test.tsx
+++ b/src/pages/__tests__/CreatorDetailPage.integration.test.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Routes, Route } from 'react-router';
 import CreatorDetailPage from '@/pages/CreatorDetailPage';
 import { courseService } from '@/services/course.service';
+import { ApiError } from '@/services/api.service';
 
 vi.mock('@/services/course.service', () => ({
 	courseService: {
@@ -49,14 +50,17 @@ function makeFreshQueryClient() {
 
 describe('CreatorDetailPage Integration', () => {
 	let queryClient: QueryClient;
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
 	beforeEach(() => {
 		queryClient = makeFreshQueryClient();
 		mockGetCourse.mockReset();
+		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 	});
 
 	afterEach(() => {
 		vi.clearAllMocks();
+		consoleErrorSpy.mockRestore();
 	});
 
 	it('renders details, applies bpsToPercent, and formats fees as percentages', async () => {
@@ -106,5 +110,42 @@ describe('CreatorDetailPage Integration', () => {
 		// Assert raw bps values are not visible in the rendered output
 		expect(screen.queryByText('500')).not.toBeInTheDocument();
 		expect(screen.queryByText('250')).not.toBeInTheDocument();
+	});
+
+	it('renders a creator-not-found state for a 404 response on the canonical /creator route', async () => {
+		mockGetCourse.mockRejectedValue(
+			new ApiError('Creator not found', 404, {
+				success: false,
+				message: 'Creator not found',
+			})
+		);
+
+		render(
+			<QueryClientProvider client={queryClient}>
+				<MemoryRouter initialEntries={['/creator/unknown-id']}>
+					<Routes>
+						<Route path="/creator/:id" element={<CreatorDetailPage />} />
+						<Route path="/creators" element={<div>Creators list</div>} />
+					</Routes>
+				</MemoryRouter>
+			</QueryClientProvider>
+		);
+
+		expect(
+			await screen.findByRole('heading', { name: 'Creator not found' })
+		).toBeInTheDocument();
+		expect(
+			screen.getByText(/we couldn't find a creator with that id/i)
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('link', { name: /back to creators/i })
+		).toHaveAttribute('href', '/creators');
+
+		expect(
+			screen.queryByLabelText(/loading creator profile/i)
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText(/this creator page could not load/i)
+		).not.toBeInTheDocument();
 	});
 });

--- a/src/pages/__tests__/LandingPage.holdingsGrandTotal.integration.test.tsx
+++ b/src/pages/__tests__/LandingPage.holdingsGrandTotal.integration.test.tsx
@@ -1,0 +1,278 @@
+import type { ComponentProps, ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import LandingPage from '@/pages/LandingPage';
+import { courseService, type Course } from '@/services/course.service';
+import type { HeldKeyPosition } from '@/utils/portfolioValue.utils';
+
+const holdingsStore = vi.hoisted(() => {
+	let holdings: HeldKeyPosition[] = [];
+	const listeners = new Set<() => void>();
+
+	return {
+		get: () => holdings,
+		set: (next: HeldKeyPosition[]) => {
+			holdings = next;
+			listeners.forEach(listener => listener());
+		},
+		subscribe: (listener: () => void) => {
+			listeners.add(listener);
+			return () => listeners.delete(listener);
+		},
+	};
+});
+
+vi.mock('@/hooks/useWallet', async () => {
+	const React = await import('react');
+
+	return {
+		useWalletHoldings: () => ({
+			data: React.useSyncExternalStore(
+				holdingsStore.subscribe,
+				holdingsStore.get,
+				holdingsStore.get
+			),
+		}),
+		useTradeMutation: () => ({
+			isPending: false,
+			mutateAsync: async ({
+				creatorId,
+				amount,
+				priceStroops,
+				price,
+			}: {
+				creatorId: string;
+				amount: number;
+				priceStroops: number | null | undefined;
+				price: number | null | undefined;
+			}) => {
+				const current = holdingsStore.get();
+				const existing = current.find(entry => entry.creatorId === creatorId);
+
+				if (existing) {
+					holdingsStore.set(
+						current.map(entry =>
+							entry.creatorId === creatorId
+								? {
+										...entry,
+										quantity: (entry.quantity ?? 0) + amount,
+										priceStroops,
+										price,
+										pending: false,
+									}
+								: entry
+						)
+					);
+				} else {
+					holdingsStore.set([
+						...current,
+						{
+							creatorId,
+							quantity: amount,
+							priceStroops,
+							price,
+							pending: false,
+						},
+					]);
+				}
+
+				return { success: true as const };
+			},
+		}),
+	};
+});
+
+vi.mock('@/services/course.service', () => ({
+	courseService: { getCourses: vi.fn() },
+}));
+
+vi.mock('@/utils/toast.util', () => ({
+	default: {
+		message: vi.fn(),
+		success: vi.fn(),
+		error: vi.fn(),
+		loading: vi.fn(),
+		transactionSuccess: vi.fn(),
+	},
+}));
+
+vi.mock('@/hooks/useNetworkMismatch', () => ({
+	useNetworkMismatch: () => ({
+		isMismatch: false,
+		expectedChainName: 'Stellar Testnet',
+	}),
+}));
+
+vi.mock('@/hooks/useStaleData', () => ({
+	useStaleData: () => ({
+		stale: false,
+		ageMs: 0,
+		msUntilStale: 60_000,
+		revalidate: vi.fn(),
+	}),
+}));
+
+vi.mock('@/components/common/StellarConnectionQualityBadge', async () => {
+	const React = await import('react');
+
+	return {
+		default: () => React.createElement('div', { role: 'status' }, 'RPC good'),
+	};
+});
+
+vi.mock('@/components/common/CreatorCard', async () => {
+	const React = await import('react');
+
+	return {
+		default: ({ creator }: { creator: { title: string } }) =>
+			React.createElement(
+				'article',
+				{ 'aria-label': `Creator ${creator.title}` },
+				creator.title
+			),
+	};
+});
+
+vi.mock('@/components/common/FeaturedCreatorAudienceChip', async () => {
+	const React = await import('react');
+
+	return {
+		FeaturedCreatorAudienceChip: () =>
+			React.createElement('div', { 'data-testid': 'mock-audience-chip' }),
+	};
+});
+
+vi.mock('framer-motion', async () => {
+	const React = await import('react');
+	type MotionDivProps = ComponentProps<'div'> & {
+		layout?: boolean;
+		transition?: unknown;
+	};
+
+	return {
+		AnimatePresence: ({ children }: { children: ReactNode }) =>
+			React.createElement(React.Fragment, null, children),
+		LayoutGroup: ({ children }: { children: ReactNode }) =>
+			React.createElement(React.Fragment, null, children),
+		motion: {
+			div: ({ children, ...props }: MotionDivProps) => {
+				const { layout, transition, ...divProps } = props;
+				void layout;
+				void transition;
+
+				return React.createElement('div', divProps, children);
+			},
+			h1: ({ children, ...props }: ComponentProps<'h1'>) =>
+				React.createElement('h1', props, children),
+			button: ({ children, ...props }: ComponentProps<'button'>) =>
+				React.createElement('button', props, children),
+		},
+	};
+});
+
+const mockGetCourses = vi.mocked(courseService.getCourses);
+
+const creators: Course[] = [
+	{
+		id: '1',
+		title: 'Featured Creator',
+		description: 'Featured creator',
+		price: 100,
+		priceStroops: 1_000_000_000,
+		creatorShareSupply: 100,
+		instructorId: 'featured',
+		category: 'Art',
+		level: 'BEGINNER',
+		isVerified: true,
+	},
+	{
+		id: '2',
+		title: 'Existing Creator',
+		description: 'Existing creator',
+		price: 500,
+		priceStroops: 5_000_000_000,
+		creatorShareSupply: 50,
+		instructorId: 'existing',
+		category: 'Tech',
+		level: 'ADVANCED',
+		isVerified: true,
+	},
+];
+
+const mockMatchMedia = () => {
+	Object.defineProperty(window, 'matchMedia', {
+		writable: true,
+		value: vi.fn().mockImplementation((query: string) => ({
+			matches: false,
+			media: query,
+			onchange: null,
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+			addListener: vi.fn(),
+			removeListener: vi.fn(),
+			dispatchEvent: vi.fn(),
+		})),
+	});
+};
+
+describe('LandingPage holdings grand total after buy confirmation (#660)', () => {
+	beforeEach(() => {
+		mockMatchMedia();
+		window.localStorage.clear();
+		window.sessionStorage.clear();
+		mockGetCourses.mockReset();
+		mockGetCourses.mockResolvedValue(creators);
+		holdingsStore.set([
+			{
+				creatorId: '1',
+				quantity: 0,
+				priceStroops: 1_000_000_000,
+				price: 100,
+				pending: false,
+			},
+			{
+				creatorId: '2',
+				quantity: 1,
+				priceStroops: 5_000_000_000,
+				price: 500,
+				pending: false,
+			},
+		]);
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('updates the holdings grand total immediately after a buy confirmation and shows the new holding entry', async () => {
+		render(
+			<QueryClientProvider
+				client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+			>
+				<MemoryRouter>
+					<LandingPage />
+				</MemoryRouter>
+			</QueryClientProvider>
+		);
+
+		expect(await screen.findByText('500 XLM')).toBeInTheDocument();
+		expect(screen.getByText('1 keys · 500 XLM')).toBeInTheDocument();
+		expect(screen.queryByText('2 keys · 100 XLM')).not.toBeInTheDocument();
+
+		const [buyButton] = screen.getAllByRole('button', { name: 'Buy' });
+		fireEvent.click(buyButton);
+
+		fireEvent.change(await screen.findByTestId('trade-dialog-amount'), {
+			target: { value: '2' },
+		});
+		fireEvent.click(screen.getByTestId('trade-dialog-confirm'));
+
+		await waitFor(() => {
+			expect(screen.getByText('700 XLM')).toBeInTheDocument();
+		});
+		expect(screen.getByText('2 keys · 100 XLM')).toBeInTheDocument();
+		expect(screen.getByText('1 keys · 500 XLM')).toBeInTheDocument();
+	});
+});

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -8,6 +8,14 @@ export const routes = [
 		element: <HomePage />,
 	},
 	{
+		path: '/creators',
+		element: <HomePage />,
+	},
+	{
+		path: '/creator/:id',
+		element: <CreatorDetailPage />,
+	},
+	{
 		path: '/creators/:id',
 		element: <CreatorDetailPage />,
 	},


### PR DESCRIPTION
Closes #656
Closes #658
Closes #659
Closes #660

## Summary

This PR covers four related marketplace and wallet reliability issues:

- adds a distinct creator not-found state for 404 creator profile responses
- adds integration coverage for wallet activity ordering and Buy/Sell labels
- adds structured debug logging for wallet disconnect session duration
- adds integration coverage for holdings grand total updates after a confirmed buy

## What changed

### #656 Creator profile 404 state

- added canonical `/creator/:id` route support while keeping existing creator detail routing
- preserved API 404 errors in the creator detail flow instead of collapsing them into a generic failure
- updated the creator page error boundary to render a dedicated not-found state with a back-to-creators action
- added an integration test asserting:
  - not-found state is shown for a 404 response
  - loading skeleton is gone after resolution
  - generic error copy is not shown
  - back-to-creators navigation is present

### #658 Wallet activity feed ordering

- updated `TransactionHistory` to sort entries in descending timestamp order before rendering
- added an integration test asserting:
  - trades render in reverse chronological order
  - Buy and Sell labels are correct
  - creator handles and trade amounts are visible for each entry

### #659 Wallet disconnect session logging

- added a reusable wallet disconnect log helper
- record connect time while the wallet session is active
- emit a structured debug log on disconnect with:
  - `truncated_address`
  - `session_duration_ms`
  - `disconnected_at`
- ensured the full wallet address is not logged
- ensured the disconnect log is suppressed in the test environment
- added unit/integration coverage for the log payload and environment guard

### #660 Holdings grand total live update

- added an integration test that simulates a confirmed buy updating the holdings cache
- asserted the holdings total updates from `500 XLM` to `700 XLM` without reload
- asserted the new holding entry becomes visible alongside the existing one

## Validation

- `pnpm vitest run src/pages/__tests__/CreatorDetailPage.integration.test.tsx src/components/common/__tests__/TransactionHistory.order.integration.test.tsx src/components/common/__tests__/ConnectWalletButton.test.tsx src/lib/__tests__/walletSessionLog.test.ts src/pages/__tests__/LandingPage.holdingsGrandTotal.integration.test.tsx --reporter=dot`
- `pnpm lint`
- `pnpm build`