### PR TITLE
feat(components): add unit tests and CTA/message support for EmptySta…

### DIFF
--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -1,12 +1,23 @@
+import { Link } from 'react-router';
 import { cn } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 import { RotateCcw } from 'lucide-react';
 import { EMPTY_STATE_ILLUSTRATION_SIZES } from './emptyStateIllustration.config';
 
-interface EmptyStateProps {
-	image: string;
-	title: string;
-	description: string;
+export interface EmptyStateCTAConfig {
+	label?: string;
+	text?: string;
+	href?: string;
+	onClick?: () => void;
+}
+
+export interface EmptyStateProps {
+	image?: string;
+	title?: string;
+	description?: string;
+	message?: string;
+	cta?: EmptyStateCTAConfig | string;
+	ctaHref?: string;
 	className?: string;
 	onReset?: () => void;
 }
@@ -15,9 +26,24 @@ const EmptyState: React.FC<EmptyStateProps> = ({
 	image,
 	title,
 	description,
+	message,
+	cta,
+	ctaHref,
 	className,
 	onReset,
 }: EmptyStateProps) => {
+	const displayTitle = title;
+	const displayMessage = message ?? description;
+	const ariaLabelText = title || message || description || 'Empty state';
+
+	const ctaObject = typeof cta === 'object' ? cta : undefined;
+	const ctaLabel =
+		ctaObject?.label ??
+		ctaObject?.text ??
+		(typeof cta === 'string' ? cta : undefined);
+	const resolvedHref = ctaObject?.href ?? ctaHref;
+	const resolvedOnClick = ctaObject?.onClick;
+
 	return (
 		<div
 			className={cn(
@@ -25,33 +51,56 @@ const EmptyState: React.FC<EmptyStateProps> = ({
 				className
 			)}
 			role="status"
-			aria-label={title}
+			aria-label={ariaLabelText}
 		>
-			<div
-				className={cn(
-					'relative mb-6 flex items-center justify-center',
-					EMPTY_STATE_ILLUSTRATION_SIZES.heroFrame
-				)}
-			>
-				<div className="absolute inset-0 size-full rounded-full bg-amber-500/10 blur-2xl" />
-				<img
-					src={image}
+			{image && (
+				<div
 					className={cn(
-						'relative z-10 opacity-60 grayscale transition-all duration-500 hover:opacity-80 hover:grayscale-0',
-						EMPTY_STATE_ILLUSTRATION_SIZES.heroVisual
+						'relative mb-6 flex items-center justify-center',
+						EMPTY_STATE_ILLUSTRATION_SIZES.heroFrame
 					)}
-					alt=""
-					aria-hidden="true"
-				/>
-			</div>
-			<h2 className="font-grotesque text-2xl font-black tracking-tight text-white mb-2">
-				{title}
-			</h2>
-			<p className="max-w-[280px] font-jakarta text-sm leading-relaxed text-white/50 mb-8">
-				{description}
-			</p>
+				>
+					<div className="absolute inset-0 size-full rounded-full bg-amber-500/10 blur-2xl" />
+					<img
+						src={image}
+						className={cn(
+							'relative z-10 opacity-60 grayscale transition-all duration-500 hover:opacity-80 hover:grayscale-0',
+							EMPTY_STATE_ILLUSTRATION_SIZES.heroVisual
+						)}
+						alt=""
+						aria-hidden="true"
+					/>
+				</div>
+			)}
+			{displayTitle && (
+				<h2 className="font-grotesque text-2xl font-black tracking-tight text-white mb-2">
+					{displayTitle}
+				</h2>
+			)}
+			{displayMessage !== undefined && (
+				<p className="max-w-[280px] font-jakarta text-sm leading-relaxed text-white/50 mb-8">
+					{displayMessage}
+				</p>
+			)}
 
-			{onReset && (
+			{resolvedHref && ctaLabel ? (
+				<Link
+					to={resolvedHref}
+					aria-label={ctaLabel}
+					className="inline-flex items-center justify-center rounded-xl border border-white/10 bg-white/5 px-6 py-2.5 text-sm font-bold text-white transition-all hover:border-amber-500/30 hover:bg-amber-500/10"
+				>
+					{ctaLabel}
+				</Link>
+			) : ctaLabel ? (
+				<Button
+					onClick={resolvedOnClick}
+					variant="outline"
+					aria-label={ctaLabel}
+					className="rounded-xl border-white/10 bg-white/5 px-6 font-bold text-white transition-all hover:border-amber-500/30 hover:bg-amber-500/10"
+				>
+					{ctaLabel}
+				</Button>
+			) : onReset ? (
 				<Button
 					onClick={onReset}
 					variant="outline"
@@ -61,9 +110,10 @@ const EmptyState: React.FC<EmptyStateProps> = ({
 					<RotateCcw className="mr-2 size-4" aria-hidden="true" />
 					Reset Search
 				</Button>
-			)}
+			) : null}
 		</div>
 	);
 };
 
 export default EmptyState;
+

--- a/src/components/common/__tests__/EmptyState.test.tsx
+++ b/src/components/common/__tests__/EmptyState.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+import { describe, expect, it, vi } from 'vitest';
+import EmptyState from '../EmptyState';
+
+const LocationDisplay = () => {
+	const location = useLocation();
+	return <div data-testid="location-display">{location.pathname}</div>;
+};
+
+describe('EmptyState', () => {
+	it('renders message and CTA when both are provided and asserts both are visible', () => {
+		render(
+			<MemoryRouter>
+				<EmptyState
+					message="No records found in this context"
+					cta={{ label: 'Go to Marketplace', href: '/marketplace' }}
+				/>
+			</MemoryRouter>
+		);
+
+		expect(
+			screen.getByText('No records found in this context')
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('link', { name: 'Go to Marketplace' })
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole('link', { name: 'Go to Marketplace' })
+		).toHaveAttribute('href', '/marketplace');
+	});
+
+	it('renders with only a message (no CTA) and asserts the CTA element is absent', () => {
+		render(<EmptyState message="No activity recorded yet" />);
+
+		expect(screen.getByText('No activity recorded yet')).toBeInTheDocument();
+		expect(screen.queryByRole('link')).not.toBeInTheDocument();
+		expect(screen.queryByRole('button')).not.toBeInTheDocument();
+	});
+
+	it('clicks the CTA and asserts navigation to the provided href is triggered', () => {
+		render(
+			<MemoryRouter initialEntries={['/']}>
+				<Routes>
+					<Route
+						path="/"
+						element={
+							<EmptyState
+								message="Start your journey"
+								cta={{ label: 'Explore Creators', href: '/creators' }}
+							/>
+						}
+					/>
+					<Route
+						path="/creators"
+						element={<div data-testid="creators-page">Creators Page</div>}
+					/>
+				</Routes>
+				<LocationDisplay />
+			</MemoryRouter>
+		);
+
+		expect(screen.getByTestId('location-display')).toHaveTextContent('/');
+
+		const ctaLink = screen.getByRole('link', { name: 'Explore Creators' });
+		fireEvent.click(ctaLink);
+
+		expect(screen.getByTestId('creators-page')).toBeInTheDocument();
+		expect(screen.getByTestId('location-display')).toHaveTextContent('/creators');
+	});
+
+	it('renders with an empty message string and asserts the component renders without error', () => {
+		const { container } = render(<EmptyState message="" />);
+
+		expect(container).toBeInTheDocument();
+		expect(screen.getByRole('status')).toBeInTheDocument();
+	});
+
+	it('supports cta specified as string with ctaHref prop', () => {
+		render(
+			<MemoryRouter>
+				<EmptyState
+					message="No tokens found"
+					cta="Browse Tokens"
+					ctaHref="/tokens"
+				/>
+			</MemoryRouter>
+		);
+
+		const link = screen.getByRole('link', { name: 'Browse Tokens' });
+		expect(link).toBeInTheDocument();
+		expect(link).toHaveAttribute('href', '/tokens');
+	});
+
+	it('triggers onClick handler when cta is an action button without href', () => {
+		const handleAction = vi.fn();
+		render(
+			<EmptyState
+				message="Filter applied with zero matches"
+				cta={{ label: 'Clear Filters', onClick: handleAction }}
+			/>
+		);
+
+		const button = screen.getByRole('button', { name: 'Clear Filters' });
+		expect(button).toBeInTheDocument();
+
+		fireEvent.click(button);
+		expect(handleAction).toHaveBeenCalledTimes(1);
+	});
+
+	it('maintains backward compatibility with title, description, image, and onReset props', () => {
+		const handleReset = vi.fn();
+		render(
+			<EmptyState
+				image="/images/no-results.png"
+				title="No creators found"
+				description="We couldn't find any creators matching your search."
+				onReset={handleReset}
+			/>
+		);
+
+		expect(
+			screen.getByRole('status', { name: 'No creators found' })
+		).toBeInTheDocument();
+		expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+			'No creators found'
+		);
+		expect(
+			screen.getByText('We couldn\'t find any creators matching your search.')
+		).toBeInTheDocument();
+
+		const resetButton = screen.getByRole('button', { name: 'Reset search results' });
+		expect(resetButton).toBeInTheDocument();
+
+		fireEvent.click(resetButton);
+		expect(handleReset).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/pages/__tests__/LandingPage.emptyState.integration.test.tsx
+++ b/src/pages/__tests__/LandingPage.emptyState.integration.test.tsx
@@ -5,6 +5,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import LandingPage from '@/pages/LandingPage';
 import { courseService, type Course } from '@/services/course.service';
 
+vi.mock('@/hooks/useWallet', () => ({
+	useTradeMutation: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useWalletHoldings: () => ({ data: [] }),
+}));
+
 vi.mock('@/services/course.service', () => ({
 	courseService: { getCourses: vi.fn() },
 }));


### PR DESCRIPTION
#closes #623 
# Pull Request: Add Unit Tests & CTA/Message Support for EmptyState Component (#623)

## Title
`feat(components): add unit tests and CTA/message support for EmptyState (#623)`

## Branch
`feat/623-empty-state-unit-tests`

---

## Description
This pull request adds complete unit test coverage for the shared [EmptyState.tsx](file:///home/timiturn3r/Documents/drips/accesslayer-client/src/components/common/EmptyState.tsx) component and updates its prop interface to cleanly support `message`, `cta`, and `ctaHref` props alongside existing `title`, `description`, `image`, and `onReset` props.

## Key Changes

### 1. Component Enhancements ([EmptyState.tsx](file:///home/timiturn3r/Documents/drips/accesslayer-client/src/components/common/EmptyState.tsx))
- Added `message`, `cta`, and `ctaHref` to `EmptyStateProps`.
- Supported `cta` as an object (`{ label?: string; text?: string; href?: string; onClick?: () => void }`) or string.
- Rendered React Router `<Link>` for routing navigation when `href` is provided.
- Gracefully handled missing images/titles and empty message strings.
- Preserved 100% backward compatibility for existing uses (`title`, `description`, `image`, `onReset`).

### 2. Unit Tests ([EmptyState.test.tsx](file:///home/timiturn3r/Documents/drips/accesslayer-client/src/components/common/__tests__/EmptyState.test.tsx))
Created comprehensive Vitest unit test suite covering:
- **Message & CTA Visibility**: Asserts both message text and CTA link element are rendered when provided.
- **CTA Absence**: Asserts no link or button element is rendered when `cta` is omitted.
- **Navigation Triggering**: Asserts clicking CTA with `href` navigates to the target route using React Router.
- **Empty Message String**: Asserts rendering `<EmptyState message="" />` completes without throwing errors.
- **String CTA & Callback Buttons**: Asserts string `cta` with `ctaHref` and button `cta` with `onClick` handler operate as expected.
- **Backward Compatibility**: Asserts legacy `title`, `description`, `image`, and `onReset` props function properly.

---

## Acceptance Criteria Checklist

| Requirement / Criterion | Status | Verification |
| :--- | :---: | :--- |
| Message and CTA both visible when provided | ✅ Pass | Tested in `EmptyState.test.tsx` |
| CTA absent when not provided | ✅ Pass | Tested in `EmptyState.test.tsx` |
| CTA click triggers navigation to correct href | ✅ Pass | Tested in `EmptyState.test.tsx` |
| Empty message string renders without error | ✅ Pass | Tested in `EmptyState.test.tsx` |
| ESLint check passes with zero errors | ✅ Pass | Verified with `pnpm lint` |

---

## How to Test

```bash
# 1. Checkout feature branch
git checkout feat/623-empty-state-unit-tests

# 2. Run unit tests for EmptyState component
PATH=/home/timiturn3r/.nvm/versions/node/v24.18.0/bin:$PATH pnpm test src/components/common/__tests__/EmptyState.test.tsx

# 3. Verify linter
PATH=/home/timiturn3r/.nvm/versions/node/v24.18.0/bin:$PATH pnpm lint
```
#closes 