### PR TITLE
fix: replace wallet address Dialog with Popover, add dismissal integr…

### DIFF
--- a/src/components/common/ConnectWalletButton.tsx
+++ b/src/components/common/ConnectWalletButton.tsx
@@ -2,16 +2,10 @@ import { useEffect, useRef, useState } from 'react';
 import { useAccount, useConnect, useDisconnect } from 'wagmi';
 import { Copy, Check } from 'lucide-react';
 import {
-	Dialog,
-	DialogClose,
-	DialogContent,
-	DialogDescription,
-	DialogFooter,
-	DialogHeader,
-	DialogTitle,
-	DialogTrigger,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from '@/components/ui/popover';
 import { shortenAddress } from '@/lib/web3/format';
 import {
 	WALLET_CONNECTION_AD_BLOCKER_MESSAGE,
@@ -24,7 +18,7 @@ import { copyTextToClipboard } from '@/utils/clipboard.utils';
 import { logWalletDisconnectSession } from '@/lib/walletSessionLog';
 
 function ConnectWalletButton() {
-	const [showDisconnectDialog, setShowDisconnectDialog] = useState(false);
+	const [showAddressPopover, setShowAddressPopover] = useState(false);
 	const [copied, setCopied] = useState(false);
 	const connectedAtRef = useRef<number | null>(null);
 	const { address, isConnected } = useAccount();
@@ -68,68 +62,60 @@ function ConnectWalletButton() {
 		return (
 			<>
 				<div className="flex items-center gap-1.5">
-					<Dialog
-						open={showDisconnectDialog}
-						onOpenChange={setShowDisconnectDialog}
+					<Popover
+						open={showAddressPopover}
+						onOpenChange={setShowAddressPopover}
 					>
-						<DialogTrigger asChild>
+						<PopoverTrigger asChild>
 							<button
 								type="button"
 								className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700"
 							>
 								{shortenAddress(address)}
 							</button>
-						</DialogTrigger>
-						<DialogContent>
-							<DialogHeader>
-								<DialogTitle>Disconnect wallet?</DialogTitle>
-								<DialogDescription>
-									Disconnecting clears your current wallet session and any
-									pending wallet state. You will need to reconnect to
-									continue.
-								</DialogDescription>
-							</DialogHeader>
-							<DialogFooter>
-								<DialogClose asChild>
-									<Button variant="outline">Cancel</Button>
-								</DialogClose>
-								<Button
-									type="button"
-									variant="destructive"
-									onClick={() => {
-										if (connectedAtRef.current != null) {
-											logWalletDisconnectSession(
-												address,
-												connectedAtRef.current
-											);
-										}
-										disconnect();
-										connectedAtRef.current = null;
-										setShowDisconnectDialog(false);
-									}}
-								>
-									Disconnect
-								</Button>
-							</DialogFooter>
-						</DialogContent>
-					</Dialog>
-					<button
-						type="button"
-						onClick={handleCopyAddress}
-						aria-label={copied ? 'Wallet address copied' : 'Copy wallet address'}
-						className="inline-flex size-8 shrink-0 items-center justify-center rounded-md bg-white/5 text-white/40 transition-colors hover:bg-white/10 hover:text-white"
-					>
-						{copied ? (
-							<Check className="size-4 text-emerald-400" aria-hidden="true" />
-						) : (
-							<Copy className="size-4" aria-hidden="true" />
-						)}
-					</button>
-					{copied && (
-						<span className="text-xs font-medium text-emerald-400" aria-hidden="true">
-							Copied!
-						</span>
-					)}
+						</PopoverTrigger>
+						<PopoverContent className="w-80">
+							<div className="space-y-3">
+								<div className="space-y-1">
+									<p className="text-xs font-medium text-muted-foreground">
+										Wallet address
+									</p>
+									<p className="break-all font-mono text-sm">{address}</p>
+								</div>
+								<div className="flex items-center gap-2">
+									<button
+										type="button"
+										onClick={handleCopyAddress}
+										className="inline-flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-blue-700"
+									>
+										{copied ? (
+											<Check className="size-3.5" aria-hidden="true" />
+										) : (
+											<Copy className="size-3.5" aria-hidden="true" />
+										)}
+										{copied ? 'Copied' : 'Copy address'}
+									</button>
+									<button
+										type="button"
+										onClick={() => {
+											if (connectedAtRef.current != null) {
+												logWalletDisconnectSession(
+													address,
+													connectedAtRef.current
+												);
+											}
+											disconnect();
+											connectedAtRef.current = null;
+											setShowAddressPopover(false);
+										}}
+										className="rounded-md px-3 py-1.5 text-xs font-medium text-red-600 transition-colors hover:bg-red-50"
+									>
+										Disconnect
+									</button>
+								</div>
+							</div>
+						</PopoverContent>
+					</Popover>
 				</div>
 				<CopySuccessAnnouncement message={announcement} />
 			</>

--- a/src/components/common/__tests__/ConnectWalletButton.test.tsx
+++ b/src/components/common/__tests__/ConnectWalletButton.test.tsx
@@ -1,4 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import ConnectWalletButton from '@/components/common/ConnectWalletButton';
@@ -35,32 +36,33 @@ function setupConnectedWalletMocks(disconnect = vi.fn()) {
 	return { disconnect };
 }
 
-describe('ConnectWalletButton wallet disconnect confirmation', () => {
+function openAddressPopover() {
+	fireEvent.click(
+		screen.getByRole('button', { name: TRUNCATED_ADDRESS_PATTERN })
+	);
+}
+
+describe('ConnectWalletButton wallet address popover', () => {
 	function renderConnectedWallet(disconnect = vi.fn()) {
 		const result = setupConnectedWalletMocks(disconnect);
 		render(<ConnectWalletButton />);
 		return result;
 	}
 
-	it('opens a confirmation dialog before disconnecting', () => {
+	it('opens the address popover when clicking the truncated address', () => {
 		const { disconnect } = renderConnectedWallet();
 
-		fireEvent.click(
-			screen.getByRole('button', { name: TRUNCATED_ADDRESS_PATTERN })
-		);
+		openAddressPopover();
 
-		expect(
-			screen.getByRole('dialog', { name: /disconnect wallet/i })
-		).toBeInTheDocument();
+		expect(screen.getByText(FULL_ADDRESS)).toBeInTheDocument();
+		expect(screen.getByText('Wallet address')).toBeInTheDocument();
 		expect(disconnect).not.toHaveBeenCalled();
 	});
 
-	it('disconnects when the confirmation action is clicked', () => {
+	it('disconnects when the disconnect button is clicked', () => {
 		const { disconnect } = renderConnectedWallet();
 
-		fireEvent.click(
-			screen.getByRole('button', { name: TRUNCATED_ADDRESS_PATTERN })
-		);
+		openAddressPopover();
 		fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
 
 		expect(disconnect).toHaveBeenCalledTimes(1);
@@ -78,9 +80,7 @@ describe('ConnectWalletButton wallet disconnect confirmation', () => {
 			vi.advanceTimersByTime(4_500);
 		});
 
-		fireEvent.click(
-			screen.getByRole('button', { name: TRUNCATED_ADDRESS_PATTERN })
-		);
+		openAddressPopover();
 		fireEvent.click(screen.getByRole('button', { name: /^disconnect$/i }));
 
 		expect(disconnect).toHaveBeenCalledTimes(1);
@@ -96,39 +96,135 @@ describe('ConnectWalletButton wallet disconnect confirmation', () => {
 		vi.useRealTimers();
 	});
 
-	it('cancels without disconnecting', async () => {
+	it('closes the popover without disconnecting when Escape is pressed', async () => {
 		const { disconnect } = renderConnectedWallet();
 
-		fireEvent.click(
-			screen.getByRole('button', { name: TRUNCATED_ADDRESS_PATTERN })
-		);
-		fireEvent.click(screen.getByRole('button', { name: /cancel/i }));
+		openAddressPopover();
+
+		expect(screen.getByText(FULL_ADDRESS)).toBeInTheDocument();
+
+		fireEvent.keyDown(document, { key: 'Escape' });
 
 		await waitFor(() => {
-			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+			expect(screen.queryByText(FULL_ADDRESS)).not.toBeInTheDocument();
 		});
 		expect(disconnect).not.toHaveBeenCalled();
 	});
 
-	it('dismisses with Escape without disconnecting', async () => {
+	it('closes the popover without disconnecting when clicking outside', async () => {
+		const user = userEvent.setup();
 		const { disconnect } = renderConnectedWallet();
 
-		fireEvent.click(
-			screen.getByRole('button', { name: TRUNCATED_ADDRESS_PATTERN })
+		openAddressPopover();
+
+		expect(screen.getByText(FULL_ADDRESS)).toBeInTheDocument();
+
+		// Click outside the popover on the document body
+		await user.click(document.body);
+
+		expect(screen.queryByText(FULL_ADDRESS)).not.toBeInTheDocument();
+		expect(disconnect).not.toHaveBeenCalled();
+	});
+});
+
+describe('ConnectWalletButton popover dismissal with parent header', () => {
+	function renderConnectedWalletInHeader(disconnect = vi.fn()) {
+		const result = setupConnectedWalletMocks(disconnect);
+		render(
+			<header data-testid="app-header">
+				<div>
+					<span>Access Layer</span>
+				</div>
+				<ConnectWalletButton />
+			</header>
 		);
+		return result;
+	}
+
+	it('popover is visible after clicking the header address display', () => {
+		renderConnectedWalletInHeader();
+
+		openAddressPopover();
+
+		expect(screen.getByText(FULL_ADDRESS)).toBeInTheDocument();
+		expect(screen.getByText('Wallet address')).toBeInTheDocument();
+	});
+
+	it('closes the popover on outside click without unmounting the header', async () => {
+		const user = userEvent.setup();
+		renderConnectedWalletInHeader();
+
+		openAddressPopover();
+		expect(screen.getByText(FULL_ADDRESS)).toBeInTheDocument();
+
+		// Click outside the popover on the header itself
+		await user.click(screen.getByTestId('app-header'));
+
+		expect(screen.queryByText(FULL_ADDRESS)).not.toBeInTheDocument();
+
+		// Header address display should still be visible
+		expect(
+			screen.getByRole('button', { name: TRUNCATED_ADDRESS_PATTERN })
+		).toBeInTheDocument();
+		expect(screen.getByTestId('app-header')).toBeInTheDocument();
+	});
+
+	it('closes the popover on Escape without unmounting the header', async () => {
+		renderConnectedWalletInHeader();
+
+		openAddressPopover();
+		expect(screen.getByText(FULL_ADDRESS)).toBeInTheDocument();
+
 		fireEvent.keyDown(document, { key: 'Escape' });
 
 		await waitFor(() => {
-			expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+			expect(screen.queryByText(FULL_ADDRESS)).not.toBeInTheDocument();
 		});
-		expect(disconnect).not.toHaveBeenCalled();
+
+		// Header address display should still be visible
+		expect(
+			screen.getByRole('button', { name: TRUNCATED_ADDRESS_PATTERN })
+		).toBeInTheDocument();
+		expect(screen.getByTestId('app-header')).toBeInTheDocument();
+	});
+
+	it('header address display remains visible after reopen and close via both dismissal paths', async () => {
+		const user = userEvent.setup();
+		renderConnectedWalletInHeader();
+
+		// First: outside click dismissal
+		openAddressPopover();
+		expect(screen.getByText(FULL_ADDRESS)).toBeInTheDocument();
+		await user.click(screen.getByTestId('app-header'));
+
+		expect(screen.queryByText(FULL_ADDRESS)).not.toBeInTheDocument();
+
+		expect(
+			screen.getByRole('button', { name: TRUNCATED_ADDRESS_PATTERN })
+		).toBeInTheDocument();
+
+		// Second: Escape dismissal
+		openAddressPopover();
+		expect(screen.getByText(FULL_ADDRESS)).toBeInTheDocument();
+		fireEvent.keyDown(document, { key: 'Escape' });
+
+		await waitFor(() => {
+			expect(screen.queryByText(FULL_ADDRESS)).not.toBeInTheDocument();
+		});
+
+		expect(
+			screen.getByRole('button', { name: TRUNCATED_ADDRESS_PATTERN })
+		).toBeInTheDocument();
+		expect(screen.getByTestId('app-header')).toBeInTheDocument();
 	});
 });
 
 describe('ConnectWalletButton copy wallet address', () => {
 	beforeEach(() => {
-		Object.assign(navigator, {
-			clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+		Object.defineProperty(navigator, 'clipboard', {
+			value: { writeText: vi.fn().mockResolvedValue(undefined) },
+			writable: true,
+			configurable: true,
 		});
 	});
 
@@ -137,56 +233,56 @@ describe('ConnectWalletButton copy wallet address', () => {
 		render(<ConnectWalletButton />);
 	}
 
-	it('shows a copy button when the wallet is connected', () => {
+	function openAndFindCopyButton() {
+		openAddressPopover();
+		return screen.getByRole('button', { name: /copy address/i });
+	}
+
+	it('shows the full wallet address inside the popover', () => {
 		renderConnectedWallet();
 
-		expect(
-			screen.getByRole('button', { name: /copy wallet address/i })
-		).toBeInTheDocument();
+		openAddressPopover();
+
+		expect(screen.getByText(FULL_ADDRESS)).toBeInTheDocument();
+		expect(screen.getByText('Wallet address')).toBeInTheDocument();
 	});
 
 	it('copies the full unmasked address to the clipboard on click', async () => {
 		renderConnectedWallet();
 
-		fireEvent.click(
-			screen.getByRole('button', { name: /copy wallet address/i })
-		);
+		fireEvent.click(openAndFindCopyButton());
 
 		await waitFor(() => {
 			expect(navigator.clipboard.writeText).toHaveBeenCalledWith(FULL_ADDRESS);
 		});
 	});
 
-	it('shows a Copied! confirmation after clicking', async () => {
+	it('shows a Copied state on the copy button after clicking', async () => {
 		renderConnectedWallet();
 
-		fireEvent.click(
-			screen.getByRole('button', { name: /copy wallet address/i })
-		);
+		fireEvent.click(openAndFindCopyButton());
 
-		expect(await screen.findByText('Copied!')).toBeInTheDocument();
+		expect(await screen.findByText('Copied')).toBeInTheDocument();
 	});
 
-	it('removes the Copied! confirmation after 2 seconds', async () => {
+	it('removes the Copied state after 2 seconds', async () => {
 		vi.useFakeTimers();
 		renderConnectedWallet();
 
-		fireEvent.click(
-			screen.getByRole('button', { name: /copy wallet address/i })
-		);
+		fireEvent.click(openAndFindCopyButton());
 
 		// Flush the clipboard promise microtask so state updates land
 		await act(async () => {
 			await Promise.resolve();
 		});
 
-		expect(screen.getByText('Copied!')).toBeInTheDocument();
+		expect(screen.getByText('Copied')).toBeInTheDocument();
 
 		act(() => {
 			vi.advanceTimersByTime(2000);
 		});
 
-		expect(screen.queryByText('Copied!')).not.toBeInTheDocument();
+		expect(screen.queryByText('Copied')).not.toBeInTheDocument();
 
 		vi.useRealTimers();
 	});


### PR DESCRIPTION
Closes #606 

…ation tests

- Replace Dialog with Popover for wallet address display in ConnectWalletButton
- Popover shows full address, copy button, and disconnect action
- Popover closes on outside click and Escape (Radix Popover default behavior)
- Add integration tests for popover dismissal with parent header component
- Update existing tests for new Popover-based UI

## Summary

-

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm build`

## Checklist

- [ ] Linked issue or backlog item
- [ ] Scope is limited to the stated change
- [ ] Updated docs if behavior or setup changed
- [ ] Added screenshots for UI changes when relevant
