### PR TITLE
fix(#703): hide Change24hBadge when price_change_24h is null

### DIFF
--- a/src/components/common/Change24hBadge.tsx
+++ b/src/components/common/Change24hBadge.tsx
@@ -9,8 +9,10 @@ interface Change24hBadgeProps {
 }
 
 const Change24hBadge: React.FC<Change24hBadgeProps> = ({ change, className }) => {
-	const isPositive = change !== undefined && change > 0;
-	const isNegative = change !== undefined && change < 0;
+	if (change == null) return null;
+
+	const isPositive = change > 0;
+	const isNegative = change < 0;
 	const formatted = formatPercent(change, { signed: true });
 
 	return (

--- a/src/components/common/__tests__/Change24hBadge.test.tsx
+++ b/src/components/common/__tests__/Change24hBadge.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Change24hBadge from '../Change24hBadge';
+
+describe('Change24hBadge', () => {
+	describe('positive change', () => {
+		it('renders green badge with up arrow for positive value', () => {
+			render(<Change24hBadge change={5.25} />);
+
+			const badge = screen.getByText('+5.25%');
+			expect(badge).toBeInTheDocument();
+			expect(badge.closest('div')).toHaveClass('text-emerald-400');
+		});
+
+		it('formats positive value to two decimal places with sign', () => {
+			render(<Change24hBadge change={3.456} />);
+			expect(screen.getByText('+3.46%')).toBeInTheDocument();
+		});
+
+		it('shows TrendingUp icon for positive change', () => {
+			const { container } = render(<Change24hBadge change={10} />);
+			const svg = container.querySelector('svg');
+			expect(svg).toBeInTheDocument();
+			expect(svg).toHaveClass('lucide-trending-up');
+		});
+	});
+
+	describe('negative change', () => {
+		it('renders red badge with down arrow for negative value', () => {
+			render(<Change24hBadge change={-2.1} />);
+
+			const badge = screen.getByText('-2.1%');
+			expect(badge).toBeInTheDocument();
+			expect(badge.closest('div')).toHaveClass('text-red-400');
+		});
+
+		it('formats negative value to two decimal places', () => {
+			render(<Change24hBadge change={-0.123} />);
+			expect(screen.getByText('-0.12%')).toBeInTheDocument();
+		});
+
+		it('shows TrendingDown icon for negative change', () => {
+			const { container } = render(<Change24hBadge change={-5} />);
+			const svg = container.querySelector('svg');
+			expect(svg).toBeInTheDocument();
+			expect(svg).toHaveClass('lucide-trending-down');
+		});
+	});
+
+	describe('zero change', () => {
+		it('renders grey badge with dash for zero value', () => {
+			render(<Change24hBadge change={0} />);
+
+			const badge = screen.getByText('0%');
+			expect(badge).toBeInTheDocument();
+			expect(badge.closest('div')).toHaveClass('text-white/40');
+		});
+
+		it('shows Minus icon for zero change', () => {
+			const { container } = render(<Change24hBadge change={0} />);
+			const svg = container.querySelector('svg');
+			expect(svg).toBeInTheDocument();
+			expect(svg).toHaveClass('lucide-minus');
+		});
+	});
+
+	describe('null / undefined (no data)', () => {
+		it('renders nothing when change is undefined', () => {
+			const { container } = render(<Change24hBadge />);
+			expect(container.innerHTML).toBe('');
+		});
+
+		it('renders nothing when change is explicitly null', () => {
+			const { container } = render(<Change24hBadge change={null} />);
+			expect(container.innerHTML).toBe('');
+		});
+	});
+
+	describe('edge cases', () => {
+		it('renders correct badge for very small positive value', () => {
+			render(<Change24hBadge change={0.01} />);
+			expect(screen.getByText('+0.01%')).toBeInTheDocument();
+		});
+
+		it('renders correct badge for very small negative value', () => {
+			render(<Change24hBadge change={-0.01} />);
+			expect(screen.getByText('-0.01%')).toBeInTheDocument();
+		});
+
+		it('applies custom className', () => {
+			render(<Change24hBadge change={1} className="my-custom-class" />);
+			const badge = screen.getByText('+1%').closest('div');
+			expect(badge).toHaveClass('my-custom-class');
+		});
+
+		it('includes accessible title with 24h context', () => {
+			render(<Change24hBadge change={5} />);
+			expect(screen.getByTitle('+5% (24h)')).toBeInTheDocument();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #703

The `Change24hBadge` component was rendering a grey dash badge even when the `change24h` field was `null` or `undefined` from the API. Per the issue requirements, the badge should be absent (not rendered) when there is no 24h price data.

## Changes

- **`Change24hBadge.tsx`**: Added early return (`return null`) when `change` is `null` or `undefined`, so no badge renders for creators without 24h price data
- **`Change24hBadge.test.tsx`** (new): Added 14 unit tests covering:
  - Positive values render green badge with TrendingUp icon
  - Negative values render red badge with TrendingDown icon
  - Zero renders grey badge with Minus icon
  - `undefined` and explicit `null` render nothing
  - Two decimal place formatting with +/- sign
  - Custom className support
  - Accessible title with 24h context

## Acceptance Criteria

- [x] Green up-arrow badge for positive 24h change
- [x] Red down-arrow badge for negative 24h change
- [x] Grey dash badge for 0% change
- [x] No badge rendered when the field is null
- [x] Percentage formatted to two decimal places with sign
- [x] Unit tests for all badge variants