### PR TITLE
feat(observability): warn on failed optimistic rollback due to missing snapshot

### DIFF
--- a/src/hooks/__tests__/optimisticRollbackSnapshotMissing.test.ts
+++ b/src/hooks/__tests__/optimisticRollbackSnapshotMissing.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Warn-level log when an optimistic rollback cannot find its snapshot (#674).
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { useTradeMutation, type TradeVariables } from '../useWallet';
+import { queryKeys } from '@/lib/queryKeys';
+
+vi.mock('@/utils/toast.util', () => ({
+	default: {
+		message: vi.fn(),
+		success: vi.fn(),
+		error: vi.fn(),
+		loading: vi.fn(),
+		transactionSuccess: vi.fn(),
+	},
+}));
+
+function createWrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return {
+		wrapper: function Wrapper({ children }: { children: React.ReactNode }) {
+			return React.createElement(
+				QueryClientProvider,
+				{ client: queryClient },
+				children
+			);
+		},
+		queryClient,
+	};
+}
+
+const address = 'GWALLET';
+
+const BUY_VARIABLES: TradeVariables = {
+	creatorId: 'creator-a',
+	amount: 2,
+	priceStroops: 500_000,
+	price: 0.05,
+};
+
+const SELL_VARIABLES: TradeVariables = {
+	creatorId: 'creator-b',
+	amount: -2,
+	priceStroops: 500_000,
+	price: 0.05,
+};
+
+describe('useTradeMutation rollback snapshot-missing warning (#674)', () => {
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+	const originalEnv = process.env.NODE_ENV;
+
+	beforeEach(() => {
+		process.env.NODE_ENV = 'development';
+		warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		warnSpy.mockRestore();
+		process.env.NODE_ENV = originalEnv;
+	});
+
+	it('emits a warn log with all required fields when onMutate fails to capture a snapshot', async () => {
+		const { wrapper, queryClient } = createWrapper();
+		vi.spyOn(queryClient, 'cancelQueries').mockRejectedValueOnce(
+			new Error('cancelQueries failed')
+		);
+
+		const { result } = renderHook(() => useTradeMutation(address), { wrapper });
+
+		result.current.mutate(BUY_VARIABLES);
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			'[optimistic-rollback]',
+			expect.objectContaining({
+				cache_key: JSON.stringify(queryKeys.wallet.holdings(address)),
+				action: 'buy',
+				creator_id: 'creator-a',
+				reason: 'snapshot_missing',
+				failed_at: expect.any(String),
+			})
+		);
+	});
+
+	it('identifies action as sell for a negative trade amount', async () => {
+		const { wrapper, queryClient } = createWrapper();
+		vi.spyOn(queryClient, 'cancelQueries').mockRejectedValueOnce(
+			new Error('cancelQueries failed')
+		);
+
+		const { result } = renderHook(() => useTradeMutation(address), { wrapper });
+
+		result.current.mutate(SELL_VARIABLES);
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+
+		expect(warnSpy).toHaveBeenCalledWith(
+			'[optimistic-rollback]',
+			expect.objectContaining({ action: 'sell', creator_id: 'creator-b' })
+		);
+	});
+
+	it('includes failed_at as an ISO timestamp', async () => {
+		const { wrapper, queryClient } = createWrapper();
+		vi.spyOn(queryClient, 'cancelQueries').mockRejectedValueOnce(
+			new Error('cancelQueries failed')
+		);
+
+		const { result } = renderHook(() => useTradeMutation(address), { wrapper });
+
+		result.current.mutate(BUY_VARIABLES);
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+
+		const call = warnSpy.mock.calls.find(c => c[0] === '[optimistic-rollback]');
+		const log = call?.[1] as Record<string, unknown>;
+		expect(log.failed_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+	});
+
+	it('does not warn when onMutate captures a snapshot normally', async () => {
+		const { wrapper, queryClient } = createWrapper();
+		queryClient.setQueryData(queryKeys.wallet.holdings(address), [
+			{ creatorId: 'creator-a', quantity: 1, priceStroops: null, price: null, pending: false },
+		]);
+
+		const { result } = renderHook(() => useTradeMutation(address), { wrapper });
+
+		result.current.mutate(BUY_VARIABLES);
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it('does not emit the warn log in test environment', async () => {
+		process.env.NODE_ENV = 'test';
+		warnSpy.mockClear();
+
+		const { wrapper, queryClient } = createWrapper();
+		vi.spyOn(queryClient, 'cancelQueries').mockRejectedValueOnce(
+			new Error('cancelQueries failed')
+		);
+
+		const { result } = renderHook(() => useTradeMutation(address), { wrapper });
+
+		result.current.mutate(BUY_VARIABLES);
+
+		await waitFor(() => expect(result.current.isError).toBe(true));
+
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+});

--- a/src/hooks/__tests__/transactionFailureLog.test.ts
+++ b/src/hooks/__tests__/transactionFailureLog.test.ts
@@ -19,12 +19,15 @@ const createWrapper = () => {
 		},
 	});
 
-	return ({ children }: { children: ReactNode }) =>
-		React.createElement(
-			QueryClientProvider,
-			{ client: queryClient },
-			children
-		);
+	return {
+		wrapper: ({ children }: { children: ReactNode }) =>
+			React.createElement(
+				QueryClientProvider,
+				{ client: queryClient },
+				children
+			),
+		queryClient,
+	};
 };
 
 describe('useTradeMutation transaction failure logging', () => {
@@ -42,7 +45,7 @@ describe('useTradeMutation transaction failure logging', () => {
 	});
 
 	it('emits structured log on transaction failure with all required fields', async () => {
-		const wrapper = createWrapper();
+		const { wrapper, queryClient } = createWrapper();
 		const address = 'GWALLET1234567890ABCDEFGHIJ';
 		const { result } = renderHook(() => useTradeMutation(address), {
 			wrapper,
@@ -57,7 +60,7 @@ describe('useTradeMutation transaction failure logging', () => {
 
 		// Trigger mutation failure by throwing an error
 		const error = new Error('Insufficient funds');
-		vi.mocked(result.current.mutateAsync).mockRejectedValueOnce(error);
+		vi.spyOn(queryClient, 'cancelQueries').mockRejectedValueOnce(error);
 
 		result.current.mutate(variables);
 
@@ -77,7 +80,7 @@ describe('useTradeMutation transaction failure logging', () => {
 	});
 
 	it('truncates wallet address to first 4 + last 4 characters', async () => {
-		const wrapper = createWrapper();
+		const { wrapper, queryClient } = createWrapper();
 		const address = 'GWALLET1234567890ABCDEFGHIJ';
 		const { result } = renderHook(() => useTradeMutation(address), {
 			wrapper,
@@ -91,7 +94,7 @@ describe('useTradeMutation transaction failure logging', () => {
 		};
 
 		const error = new Error('Network timeout');
-		vi.mocked(result.current.mutateAsync).mockRejectedValueOnce(error);
+		vi.spyOn(queryClient, 'cancelQueries').mockRejectedValueOnce(error);
 
 		result.current.mutate(variables);
 
@@ -108,7 +111,7 @@ describe('useTradeMutation transaction failure logging', () => {
 	});
 
 	it('correctly identifies action as sell for negative amount', async () => {
-		const wrapper = createWrapper();
+		const { wrapper, queryClient } = createWrapper();
 		const { result } = renderHook(
 			() => useTradeMutation('GWALLET1234567890ABCDEFGHIJ'),
 			{ wrapper }
@@ -122,7 +125,7 @@ describe('useTradeMutation transaction failure logging', () => {
 		};
 
 		const error = new Error('Wallet locked');
-		vi.mocked(result.current.mutateAsync).mockRejectedValueOnce(error);
+		vi.spyOn(queryClient, 'cancelQueries').mockRejectedValueOnce(error);
 
 		result.current.mutate(variables);
 
@@ -139,7 +142,7 @@ describe('useTradeMutation transaction failure logging', () => {
 	});
 
 	it('captures error name or message as error_code', async () => {
-		const wrapper = createWrapper();
+		const { wrapper, queryClient } = createWrapper();
 		const { result } = renderHook(
 			() => useTradeMutation('GWALLET1234567890ABCDEFGHIJ'),
 			{ wrapper }
@@ -160,7 +163,7 @@ describe('useTradeMutation transaction failure logging', () => {
 		}
 
 		const error = new CustomError('User declined signature');
-		vi.mocked(result.current.mutateAsync).mockRejectedValueOnce(error);
+		vi.spyOn(queryClient, 'cancelQueries').mockRejectedValueOnce(error);
 
 		result.current.mutate(variables);
 
@@ -179,7 +182,7 @@ describe('useTradeMutation transaction failure logging', () => {
 		process.env.NODE_ENV = 'test';
 		debugSpy.mockClear();
 
-		const wrapper = createWrapper();
+		const { wrapper, queryClient } = createWrapper();
 		const { result } = renderHook(
 			() => useTradeMutation('GWALLET1234567890ABCDEFGHIJ'),
 			{ wrapper }
@@ -193,7 +196,7 @@ describe('useTradeMutation transaction failure logging', () => {
 		};
 
 		const error = new Error('Test error');
-		vi.mocked(result.current.mutateAsync).mockRejectedValueOnce(error);
+		vi.spyOn(queryClient, 'cancelQueries').mockRejectedValueOnce(error);
 
 		result.current.mutate(variables);
 
@@ -209,7 +212,7 @@ describe('useTradeMutation transaction failure logging', () => {
 	});
 
 	it('includes failed_at timestamp in ISO format', async () => {
-		const wrapper = createWrapper();
+		const { wrapper, queryClient } = createWrapper();
 		const { result } = renderHook(
 			() => useTradeMutation('GWALLET1234567890ABCDEFGHIJ'),
 			{ wrapper }
@@ -223,7 +226,7 @@ describe('useTradeMutation transaction failure logging', () => {
 		};
 
 		const error = new Error('Timestamp test');
-		vi.mocked(result.current.mutateAsync).mockRejectedValueOnce(error);
+		vi.spyOn(queryClient, 'cancelQueries').mockRejectedValueOnce(error);
 
 		result.current.mutate(variables);
 
@@ -241,7 +244,7 @@ describe('useTradeMutation transaction failure logging', () => {
 	});
 
 	it('handles non-Error rejection reasons as string', async () => {
-		const wrapper = createWrapper();
+		const { wrapper, queryClient } = createWrapper();
 		const { result } = renderHook(
 			() => useTradeMutation('GWALLET1234567890ABCDEFGHIJ'),
 			{ wrapper }
@@ -254,7 +257,7 @@ describe('useTradeMutation transaction failure logging', () => {
 			price: 0.1,
 		};
 
-		vi.mocked(result.current.mutateAsync).mockRejectedValueOnce(
+		vi.spyOn(queryClient, 'cancelQueries').mockRejectedValueOnce(
 			'String error'
 		);
 

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -90,12 +90,24 @@ export function useTradeMutation(address: string) {
 			return { previousHoldings };
 		},
 		onError: (error, variables, context) => {
+			const holdingsKey = queryKeys.wallet.holdings(address);
+
 			if (context?.previousHoldings) {
-				queryClient.setQueryData(
-					queryKeys.wallet.holdings(address),
-					context.previousHoldings
-				);
+				queryClient.setQueryData(holdingsKey, context.previousHoldings);
+			} else if (process.env.NODE_ENV !== 'test') {
+				// No snapshot was captured in onMutate (e.g. it threw before
+				// returning), so the rollback above cannot run and the cache
+				// may be left holding the optimistic (unconfirmed) update.
+				console.warn('[optimistic-rollback]', {
+					cache_key: JSON.stringify(holdingsKey),
+					action:
+						(variables as TradeVariables).amount > 0 ? 'buy' : 'sell',
+					creator_id: (variables as TradeVariables).creatorId,
+					reason: 'snapshot_missing',
+					failed_at: new Date().toISOString(),
+				});
 			}
+
 			showToast.error(getSignatureErrorMessage(error));
 
 			// Emit structured log for failed transaction


### PR DESCRIPTION
Closes #674

## Summary

If `onMutate` in `useTradeMutation` fails to capture a cache snapshot before a trade mutation fails (e.g. `queryClient.cancelQueries` throws), the rollback in `onError` has nothing to restore from and silently no-ops, leaving the wallet holdings cache stuck on the optimistic (unconfirmed) update. This adds a warn-level structured log for that specific edge case so it's visible to developers instead of failing silently.

## What changed

- **`src/hooks/useWallet.ts`** — in `useTradeMutation`'s `onError` handler, when `context?.previousHoldings` is missing (no snapshot was captured), emit:
  ```js
  console.warn('[optimistic-rollback]', {
    cache_key,   // JSON.stringify of the wallet holdings query key
    action,      // 'buy' | 'sell', derived the same way the existing [cache-invalidation]/[transaction-failed] logs do (amount > 0 ⇒ buy)
    creator_id,
    reason: 'snapshot_missing',
    failed_at,   // new Date().toISOString()
  });
  ```
  Suppressed when `process.env.NODE_ENV === 'test'`, matching the existing `[cache-invalidation]` and `[transaction-failed]` logs already in this hook. When a snapshot *is* present, the existing rollback (`setQueryData`) runs as before and no warning is emitted.

- **`src/hooks/__tests__/transactionFailureLog.test.ts`** — fixed a pre-existing bug unrelated to this issue but in the exact function this PR touches: every test in the file was calling `vi.mocked(result.current.mutateAsync).mockRejectedValueOnce(...)`, which is a no-op on `useTradeMutation`'s real (non-mocked) `mutationFn` and made all 7 tests fail with `mockRejectedValueOnce is not a function`. Switched the failure trigger to `vi.spyOn(queryClient, 'cancelQueries').mockRejectedValueOnce(...)`, the same mechanism used by the new tests below, and exposed `queryClient` from `createWrapper`. Behavior/assertions of the file are unchanged.

## New files

- **`src/hooks/__tests__/optimisticRollbackSnapshotMissing.test.ts`** — new coverage for this issue:
  - emits `[optimistic-rollback]` with all five required fields (`cache_key`, `action`, `creator_id`, `reason: 'snapshot_missing'`, `failed_at`) when `onMutate` fails to capture a snapshot (forced via a rejected `cancelQueries`)
  - correctly labels `action` as `'sell'` for a negative trade amount
  - `failed_at` is a valid ISO-8601 timestamp
  - does **not** warn when `onMutate` captures a snapshot normally and the mutation succeeds (no rollback attempted)
  - does **not** emit the warning when `NODE_ENV === 'test'`

## How to test

```bash
pnpm test src/hooks/__tests__/optimisticRollbackSnapshotMissing.test.ts
pnpm test src/hooks/__tests__/transactionFailureLog.test.ts
pnpm test src/hooks/__tests__/optimisticBuy.test.ts src/hooks/__tests__/tradeCacheInvalidation.test.ts
pnpm lint
pnpm build
```

Manually: in `useWallet.ts`, temporarily make `queryClient.cancelQueries` throw (or throttle the network so a trade fails before `onMutate` resolves) and confirm a single `console.warn('[optimistic-rollback]', {...})` appears with the five fields, and that a normal failed/succeeded trade with a captured snapshot does not log it.

## Note on test suite

`pnpm vitest run` on this branch has 33 pre-existing failures across 15 files (e.g. `bondingCurve.utils.test.ts`, `LandingPage.cardCount.integration.test.tsx`, `Web3Provider.test.tsx`) that are unrelated to this change — none touch `useWallet.ts` or its tests. These are present on `dev` prior to this branch and are out of scope here.

## Testing

- [x] `pnpm lint`
- [x] `pnpm build`

## Checklist

- [x] Linked issue (#674)
- [x] Scope is limited to the stated change
- [x] No docs changes needed (internal logging behavior)
- [x] No UI change — no screenshots
