### PR TITLE
test: add unit tests for sparkline hiding when fewer than two data points (#676)

### DIFF
--- a/src/components/common/__tests__/CreatorCard.sparkline.test.tsx
+++ b/src/components/common/__tests__/CreatorCard.sparkline.test.tsx
@@ -1,0 +1,80 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import CreatorCard from '@/components/common/CreatorCard';
+import type { Course } from '@/services/course.service';
+
+vi.mock('wagmi', () => ({
+	useAccount: () => ({ isConnected: false }),
+	useConnect: () => ({ connectAsync: vi.fn(), connectors: [] }),
+	useReconnect: () => ({ reconnectAsync: vi.fn(), connectors: [] }),
+}));
+
+vi.mock('@/hooks/useNetworkMismatch', () => ({
+	useNetworkMismatch: () => ({
+		isMismatch: false,
+		expectedChainName: 'Stellar Testnet',
+	}),
+}));
+
+vi.mock('@/hooks/useTransactionTelemetry', () => ({
+	useTransactionTelemetry: () => vi.fn(),
+}));
+
+vi.mock('@/utils/useSystemTheme', () => ({
+	useSystemTheme: () => ({ isDarkMode: true }),
+}));
+
+function createCreator(overrides: Partial<Course> = {}): Course {
+	return {
+		id: 'test-creator',
+		title: 'Test Creator',
+		description: 'A test creator.',
+		price: 10,
+		creatorShareSupply: 100,
+		instructorId: 'test',
+		category: 'Art',
+		level: 'BEGINNER',
+		...overrides,
+	};
+}
+
+describe('CreatorCard sparkline', () => {
+	it('does not render sparkline for zero price history points', () => {
+		const { container } = render(
+			<CreatorCard creator={createCreator({ priceHistory: [] })} />
+		);
+
+		expect(container.querySelector('polyline')).not.toBeInTheDocument();
+	});
+
+	it('does not render sparkline for one price history point', () => {
+		const { container } = render(
+			<CreatorCard creator={createCreator({ priceHistory: [100] })} />
+		);
+
+		expect(container.querySelector('polyline')).not.toBeInTheDocument();
+	});
+
+	it('renders sparkline for two price history points', () => {
+		const { container } = render(
+			<CreatorCard
+				creator={createCreator({ priceHistory: [100, 200] })}
+			/>
+		);
+
+		expect(container.querySelector('polyline')).toBeInTheDocument();
+	});
+
+	it('renders sparkline for seven price history points', () => {
+		const { container } = render(
+			<CreatorCard
+				creator={createCreator({
+					priceHistory: [100, 110, 120, 130, 140, 150, 160],
+				})}
+			/>
+		);
+
+		expect(container.querySelector('polyline')).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary

Add unit tests to verify the price history sparkline is properly hidden when there are fewer than two data points, since a single point cannot form a meaningful line.

## Tests Added

The new test file  contains four test cases:

1. **Zero price history points** - Asserts the sparkline (polyline element) is not in the DOM
2. **One price history point** - Asserts the sparkline is not in the DOM  
3. **Two price history points** - Asserts the sparkline IS rendered in the DOM
4. **Seven price history points** - Asserts the sparkline IS rendered in the DOM

## Acceptance Criteria Met

- ✅ Sparkline absent from DOM for zero data points
- ✅ Sparkline absent from DOM for one data point  
- ✅ Sparkline rendered for two data points
- ✅ Sparkline rendered for seven data points

## Implementation Details

The tests verify the behavior in  component which uses the  component from . The  component itself returns  when , and  has an additional guard  before rendering the sparkline section.

The tests use the existing mock setup pattern from  to mock wagmi hooks, network mismatch, transaction telemetry, and system theme.

Refs #676
closes #676