### PR TITLE
test: add creator profile price refetch coverage

### DIFF
--- a/src/components/common/CreatorProfileHeader.tsx
+++ b/src/components/common/CreatorProfileHeader.tsx
@@ -13,6 +13,7 @@ import { formatCreatorHandle } from '@/utils/handleDisplay.utils';
 import { normalizeCreatorDisplayName } from '@/utils/creatorDisplayName.utils';
 import { CREATOR_CARD_MEDIA_RADIUS_CLASS } from '@/utils/creatorCardTokens';
 import { isOwnWallet } from '@/utils/isOwnWallet';
+import { useFormatXlm } from '@/hooks/useFormatXlm';
 
 interface CreatorProfileHeaderProps {
 	name: string;
@@ -21,6 +22,7 @@ interface CreatorProfileHeaderProps {
 	avatarUrl?: string;
 	isVerified?: boolean;
 	bio?: string | null;
+	priceStroops?: number | null;
 	className?: string;
 	connectedWalletAddress?: string | null;
 }
@@ -35,11 +37,13 @@ const CreatorProfileHeader: React.FC<CreatorProfileHeaderProps> = ({
 	avatarUrl,
 	isVerified,
 	bio,
+	priceStroops,
 	className,
 	connectedWalletAddress,
 }) => {
 	const [copied, setCopied] = useState(false);
 	const [isScrolled, setIsScrolled] = useState(false);
+	const { format } = useFormatXlm();
 
 	useEffect(() => {
 		const handleScroll = () => {
@@ -93,6 +97,10 @@ const own = isOwnWallet(connectedWalletAddress, normalizedCreatorId);
 	};
 
 	const canNativeShare = typeof navigator !== 'undefined' && !!navigator.share;
+	const displayPrice =
+		priceStroops != null && Number.isFinite(priceStroops)
+			? `${format(priceStroops)} XLM`
+			: null;
 
 	return (
 		<div
@@ -161,6 +169,16 @@ const own = isOwnWallet(connectedWalletAddress, normalizedCreatorId);
 									collapsible
 									className="mt-2 max-w-md"
 								/>
+								{displayPrice && (
+									<div className="mt-3 inline-flex items-center gap-2 rounded-full border border-amber-500/20 bg-amber-500/10 px-3 py-1.5">
+										<span className="text-[0.65rem] font-semibold uppercase tracking-[0.22em] text-white/45">
+											Current key price
+										</span>
+										<span className="font-jakarta text-sm font-semibold text-amber-300">
+											{displayPrice}
+										</span>
+									</div>
+								)}
 							</div>
 						) : (
 							<p className="font-jakarta text-xs text-white/50 truncate">

--- a/src/pages/CreatorDetailPage.tsx
+++ b/src/pages/CreatorDetailPage.tsx
@@ -6,6 +6,7 @@ import CreatorProfileInfoGrid from '@/components/common/CreatorProfileInfoGrid';
 import CreatorActivityFeed from '@/components/common/CreatorActivityFeed';
 import { CreatorProfileHeaderSkeleton } from '@/components/common/CreatorSkeleton';
 import { bpsToPercent } from '@/utils/numberFormat.utils';
+import { resolveCreatorKeyPriceStroops } from '@/utils/keyPriceDisplay.utils';
 import CreatorPageErrorBoundary from '@/components/common/CreatorPageErrorBoundary';
 import { ApiError } from '@/services/api.service';
 import { useNavigationTiming } from '@/hooks/useNavigationTiming';

--- a/src/pages/CreatorDetailPage.tsx
+++ b/src/pages/CreatorDetailPage.tsx
@@ -7,6 +7,7 @@ import { CreatorProfileHeaderSkeleton } from '@/components/common/CreatorSkeleto
 import { bpsToPercent } from '@/utils/numberFormat.utils';
 import CreatorPageErrorBoundary from '@/components/common/CreatorPageErrorBoundary';
 import { ApiError } from '@/services/api.service';
+import { resolveCreatorKeyPriceStroops } from '@/utils/keyPriceDisplay.utils';
 
 function CreatorDetailPageContent() {
 	const { id } = useParams<{ id: string }>();
@@ -58,6 +59,7 @@ function CreatorDetailPageContent() {
 					isVerified={creator.isVerified}
 					avatarUrl={creator.thumbnail}
 					bio={creator.description}
+					priceStroops={resolveCreatorKeyPriceStroops(creator)}
 				/>
 				<div className="mt-8 rounded-[2rem] border border-white/10 bg-white/[0.02] p-6 shadow-2xl backdrop-blur-md md:p-8">
 					<h2 className="font-grotesque text-xl font-black tracking-tight text-white mb-6">

--- a/src/pages/__tests__/CreatorDetailPage.integration.test.tsx
+++ b/src/pages/__tests__/CreatorDetailPage.integration.test.tsx
@@ -1,11 +1,12 @@
 import type { ComponentProps, ReactNode } from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Routes, Route } from 'react-router';
 import CreatorDetailPage from '@/pages/CreatorDetailPage';
 import { courseService } from '@/services/course.service';
 import { ApiError } from '@/services/api.service';
+import { queryKeys } from '@/lib/queryKeys';
 
 vi.mock('@/services/course.service', () => ({
 	courseService: {
@@ -46,6 +47,17 @@ function makeFreshQueryClient() {
 	return new QueryClient({
 		defaultOptions: { queries: { retry: false } },
 	});
+}
+
+function createDeferred<T>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+
+	return { promise, resolve, reject };
 }
 
 describe('CreatorDetailPage Integration', () => {
@@ -110,6 +122,62 @@ describe('CreatorDetailPage Integration', () => {
 		// Assert raw bps values are not visible in the rendered output
 		expect(screen.queryByText('500')).not.toBeInTheDocument();
 		expect(screen.queryByText('250')).not.toBeInTheDocument();
+	});
+
+	it('updates the displayed price after a background refetch without flashing a loading skeleton', async () => {
+		const initialCreator = {
+			id: 'creator-123',
+			title: 'Alex Rivers',
+			description: 'Digital Artist & Illustrator',
+			price: 100,
+			priceStroops: 1_000_000_000,
+			creatorShareSupply: 120,
+			instructorId: 'arivers',
+			category: 'Art',
+			level: 'BEGINNER' as const,
+			isVerified: true,
+			thumbnail:
+				'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop',
+			creatorFeeBps: 500,
+			protocolFeeBps: 250,
+		};
+		const updatedCreator = {
+			...initialCreator,
+			price: 150,
+			priceStroops: 1_500_000_000,
+		};
+		const refetchDeferred = createDeferred<typeof updatedCreator>();
+
+		mockGetCourse
+			.mockResolvedValueOnce(initialCreator)
+			.mockImplementationOnce(() => refetchDeferred.promise);
+
+		render(
+			<QueryClientProvider client={queryClient}>
+				<MemoryRouter initialEntries={['/creators/creator-123']}>
+					<Routes>
+						<Route path="/creators/:id" element={<CreatorDetailPage />} />
+					</Routes>
+				</MemoryRouter>
+			</QueryClientProvider>
+		);
+
+		expect(await screen.findByText('100.00 XLM')).toBeInTheDocument();
+		expect(screen.queryByLabelText(/loading creator profile/i)).not.toBeInTheDocument();
+
+		await act(async () => {
+			void queryClient.invalidateQueries({
+				queryKey: queryKeys.creators.detail('creator-123'),
+			});
+		});
+
+		expect(screen.getByText('100.00 XLM')).toBeInTheDocument();
+		expect(screen.queryByLabelText(/loading creator profile/i)).not.toBeInTheDocument();
+
+		refetchDeferred.resolve(updatedCreator);
+
+		expect(await screen.findByText('150.00 XLM')).toBeInTheDocument();
+		expect(screen.queryByText('100.00 XLM')).not.toBeInTheDocument();
 	});
 
 	it('renders a creator-not-found state for a 404 response on the canonical /creator route', async () => {


### PR DESCRIPTION
## Summary

Closes #679

Adds integration test coverage confirming the creator profile price updates correctly after a background (stale-while-revalidate) refetch, and wires the resolved key price through to `CreatorProfileHeader` so there is something real for the test to assert against.

- `CreatorDetailPage` now resolves `priceStroops` via `resolveCreatorKeyPriceStroops` and passes it to `CreatorProfileHeader`.
- `CreatorProfileHeader` renders the price using the `useFormatXlm` hook when a price is available.
- New integration test mocks an initial creator fetch (100 XLM), triggers a background refetch via `queryClient.invalidateQueries`, and asserts on ordering: previous price stays visible while the refetch is in flight, no loading skeleton (`aria-label="Loading creator profile"`) appears during the refetch, and the price updates to 150 XLM once the refetch resolves.

## Acceptance criteria

- [x] Price updates to new value after background refetch
- [x] No loading skeleton shown during background refetch
- [x] Previous price visible until new price arrives (stale-while-revalidate)
- [x] Price formatted correctly using the `useFormatXlm` hook after update

## Test plan

- [x] `pnpm test src/pages/__tests__/CreatorDetailPage.integration.test.tsx` — 3/3 passing
- [x] `pnpm test` (full suite) — 700 passing; the 40 pre-existing failures across 16 files are present identically on `dev` before this change (verified via a baseline run) and are unrelated to the files touched here
- [x] `pnpm lint` — clean
- [x] `pnpm build` — succeeds