### PR TITLE
Error boundary for chart, marketplace SWR cache, and page-load perf logging

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,14 +3,12 @@ import { useEffect } from 'react';
 import { Toaster } from 'react-hot-toast';
 import { createBrowserRouter, RouterProvider } from 'react-router';
 import AppErrorBoundary from './components/common/AppErrorBoundary';
-import { useNavigationTiming } from './hooks/useNavigationTiming';
 import { routes } from './routes';
 import { useRouteChangeLogging } from './hooks/useRouteChangeLogging';
 
 const router = createBrowserRouter(routes);
 
 function App() {
-	useNavigationTiming();
 	useRouteChangeLogging();
 
 	useEffect(() => {

--- a/src/components/common/CreatorCard.tsx
+++ b/src/components/common/CreatorCard.tsx
@@ -12,6 +12,7 @@ import {
 	ExternalLink,
 } from 'lucide-react';
 import { Sparkline } from '@/components/ui/sparkline';
+import SectionErrorBoundary from '@/components/common/SectionErrorBoundary';
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -367,29 +368,36 @@ const CreatorCard: React.FC<CreatorCardProps> = ({
 				else if (latest < earliest) lineColor = '#ef4444';
 
 				return (
-					<div className="mt-3">
-						<Sparkline
-							data={creator.priceHistory}
-							color={lineColor}
-						/>
-						<table id={priceChartDescriptionId} className="sr-only">
-							<caption>{priceChartAccessibility.summary}</caption>
-							<thead>
-								<tr>
-									<th scope="col">Point</th>
-									<th scope="col">Key price</th>
-								</tr>
-							</thead>
-							<tbody>
-								{priceChartAccessibility.points.map(point => (
-									<tr key={point.label}>
-										<th scope="row">{point.label}</th>
-										<td>{point.value}</td>
+					<SectionErrorBoundary
+						sectionName="bonding curve chart"
+						title="Chart unavailable — try refreshing"
+						description=""
+						minHeight={40}
+					>
+						<div className="mt-3">
+							<Sparkline
+								data={creator.priceHistory}
+								color={lineColor}
+							/>
+							<table id={priceChartDescriptionId} className="sr-only">
+								<caption>{priceChartAccessibility.summary}</caption>
+								<thead>
+									<tr>
+										<th scope="col">Point</th>
+										<th scope="col">Key price</th>
 									</tr>
-								))}
-							</tbody>
-						</table>
-					</div>
+								</thead>
+								<tbody>
+									{priceChartAccessibility.points.map(point => (
+										<tr key={point.label}>
+											<th scope="row">{point.label}</th>
+											<td>{point.value}</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					</SectionErrorBoundary>
 				);
 			})()}
 

--- a/src/components/common/CreatorMarketplaceInfiniteList.tsx
+++ b/src/components/common/CreatorMarketplaceInfiniteList.tsx
@@ -23,6 +23,7 @@ export default function CreatorMarketplaceInfiniteList({
 		hasMore,
 		isLoadingFirstPage,
 		isFetchingNextPage,
+		isRefreshing,
 		fetchNextPage,
 	} = useInfiniteCreatorMarketplace(params);
 
@@ -44,6 +45,16 @@ export default function CreatorMarketplaceInfiniteList({
 
 	return (
 		<div data-testid="creator-marketplace-infinite-list">
+			{isRefreshing && (
+				<div
+					data-testid="creator-marketplace-refreshing-indicator"
+					role="status"
+					aria-live="polite"
+					className="mb-3 text-xs text-muted-foreground"
+				>
+					Refreshing…
+				</div>
+			)}
 			<div className="grid w-full grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
 				{creators.map(creator => (
 					<CreatorCard key={creator.id} creator={creator} />

--- a/src/components/common/SectionErrorBoundary.tsx
+++ b/src/components/common/SectionErrorBoundary.tsx
@@ -8,6 +8,17 @@ interface Props {
 	sectionName?: string;
 	minHeight?: string | number;
 	className?: string;
+	/**
+	 * Overrides the default "Something went wrong in this section" heading.
+	 * Use for a short, section-specific message (e.g. "Chart unavailable —
+	 * try refreshing").
+	 */
+	title?: string;
+	/**
+	 * Overrides the default explanatory paragraph. Pass an empty string to
+	 * show only the title (no secondary copy).
+	 */
+	description?: string;
 }
 
 interface State {
@@ -48,14 +59,16 @@ class SectionErrorBoundary extends Component<Props, State> {
 					<div className="flex flex-col items-center gap-2">
 						<AlertCircle className="h-10 w-10 text-destructive" />
 						<h3 className="text-lg font-semibold">
-							Something went wrong in this section
+							{this.props.title ?? 'Something went wrong in this section'}
 						</h3>
-						<p className="max-w-md text-sm text-muted-foreground">
-							{this.props.sectionName 
-								? `We encountered an error while loading the ${this.props.sectionName}.` 
-								: 'We encountered an error while loading this content.'}
-							Please try again or contact support if the issue persists.
-						</p>
+						{this.props.description !== '' && (
+							<p className="max-w-md text-sm text-muted-foreground">
+								{this.props.description ??
+									(this.props.sectionName
+										? `We encountered an error while loading the ${this.props.sectionName}. Please try again or contact support if the issue persists.`
+										: 'We encountered an error while loading this content. Please try again or contact support if the issue persists.')}
+							</p>
+						)}
 					</div>
 					<Button
 						variant="outline"

--- a/src/components/common/__tests__/CreatorMarketplaceInfiniteList.test.tsx
+++ b/src/components/common/__tests__/CreatorMarketplaceInfiniteList.test.tsx
@@ -40,6 +40,7 @@ const baseHookReturn = {
 	hasMore: false,
 	isLoadingFirstPage: false,
 	isFetchingNextPage: false,
+	isRefreshing: false,
 	fetchNextPage: vi.fn(),
 	error: null,
 };
@@ -138,5 +139,50 @@ describe('CreatorMarketplaceInfiniteList', () => {
 		const call = mockUseInfiniteScroll.mock.calls[0]![0];
 		expect(call.enabled).toBe(false);
 		expect(call.hasMore).toBe(true);
+	});
+
+	describe('background refresh indicator (#691)', () => {
+		it('shows a "Refreshing…" indicator while isRefreshing is true', () => {
+			mockUseInfiniteCreatorMarketplace.mockReturnValue({
+				...baseHookReturn,
+				creators: [makeCreator('a')],
+				isRefreshing: true,
+			});
+
+			render(<CreatorMarketplaceInfiniteList />);
+
+			expect(
+				screen.getByTestId('creator-marketplace-refreshing-indicator')
+			).toBeInTheDocument();
+			expect(screen.getByText('Refreshing…')).toBeInTheDocument();
+		});
+
+		it('does not show the refreshing indicator when isRefreshing is false', () => {
+			mockUseInfiniteCreatorMarketplace.mockReturnValue({
+				...baseHookReturn,
+				creators: [makeCreator('a')],
+				isRefreshing: false,
+			});
+
+			render(<CreatorMarketplaceInfiniteList />);
+
+			expect(
+				screen.queryByTestId('creator-marketplace-refreshing-indicator')
+			).not.toBeInTheDocument();
+		});
+
+		it('still renders cached creators (no spinner) while refreshing in the background', () => {
+			mockUseInfiniteCreatorMarketplace.mockReturnValue({
+				...baseHookReturn,
+				creators: [makeCreator('a'), makeCreator('b')],
+				isRefreshing: true,
+				isLoadingFirstPage: false,
+			});
+
+			render(<CreatorMarketplaceInfiniteList />);
+
+			expect(screen.queryByTestId('creator-marketplace-initial-skeleton')).not.toBeInTheDocument();
+			expect(screen.getAllByRole('article')).toHaveLength(2);
+		});
 	});
 });

--- a/src/components/common/__tests__/SectionErrorBoundary.test.tsx
+++ b/src/components/common/__tests__/SectionErrorBoundary.test.tsx
@@ -78,4 +78,86 @@ describe('SectionErrorBoundary', () => {
 		expect(alert).toHaveStyle('min-height: 500px');
 		expect(alert).toHaveClass('custom-class');
 	});
+
+	it('renders a custom title when provided', () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		render(
+			<SectionErrorBoundary title="Chart unavailable — try refreshing">
+				<BuggyComponent shouldThrow={true} />
+			</SectionErrorBoundary>
+		);
+
+		expect(
+			screen.getByText('Chart unavailable — try refreshing')
+		).toBeInTheDocument();
+		expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+	});
+
+	it('omits the description paragraph when description is an empty string', () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		render(
+			<SectionErrorBoundary title="Chart unavailable — try refreshing" description="">
+				<BuggyComponent shouldThrow={true} />
+			</SectionErrorBoundary>
+		);
+
+		expect(
+			screen.getByText('Chart unavailable — try refreshing')
+		).toBeInTheDocument();
+		expect(
+			screen.queryByText(/we encountered an error/i)
+		).not.toBeInTheDocument();
+	});
+
+	it('renders a custom description when provided', () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		render(
+			<SectionErrorBoundary description="Custom explanation text">
+				<BuggyComponent shouldThrow={true} />
+			</SectionErrorBoundary>
+		);
+
+		expect(screen.getByText('Custom explanation text')).toBeInTheDocument();
+	});
+
+	it('does not retry automatically after repeated failures (manual retry only)', () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		const { rerender } = render(
+			<SectionErrorBoundary>
+				<BuggyComponent shouldThrow={true} />
+			</SectionErrorBoundary>
+		);
+
+		expect(screen.getByRole('alert')).toBeInTheDocument();
+
+		// Re-rendering with the same throwing child (e.g. parent re-render)
+		// must NOT clear the error state on its own — only clicking Retry does.
+		rerender(
+			<SectionErrorBoundary>
+				<BuggyComponent shouldThrow={true} />
+			</SectionErrorBoundary>
+		);
+
+		expect(screen.getByRole('alert')).toBeInTheDocument();
+	});
+
+	it('logs the caught error via componentDidCatch when an error occurs', () => {
+		const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		render(
+			<SectionErrorBoundary sectionName="bonding curve chart">
+				<BuggyComponent shouldThrow={true} />
+			</SectionErrorBoundary>
+		);
+
+		expect(consoleSpy).toHaveBeenCalledWith(
+			expect.stringContaining('bonding curve chart'),
+			expect.any(Error),
+			expect.anything()
+		);
+	});
 });

--- a/src/hooks/__tests__/tradeCacheInvalidation.test.ts
+++ b/src/hooks/__tests__/tradeCacheInvalidation.test.ts
@@ -6,6 +6,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { useTradeMutation } from '../useWallet';
+import { queryKeys } from '@/lib/queryKeys';
 
 vi.mock('@/utils/toast.util', () => ({
 	default: {
@@ -17,12 +18,14 @@ vi.mock('@/utils/toast.util', () => ({
 	},
 }));
 
-function createWrapper() {
-	const queryClient = new QueryClient({
-		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-	});
-	return function Wrapper({ children }: { children: React.ReactNode }) {
-		return React.createElement(QueryClientProvider, { client: queryClient }, children);
+function createWrapper(queryClient = new QueryClient({
+	defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+})) {
+	return {
+		queryClient,
+		Wrapper: function Wrapper({ children }: { children: React.ReactNode }) {
+			return React.createElement(QueryClientProvider, { client: queryClient }, children);
+		},
 	};
 }
 
@@ -32,8 +35,8 @@ describe('useTradeMutation cache invalidation log (#636)', () => {
 		process.env.NODE_ENV = 'development';
 		const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
 
-		const wrapper = createWrapper();
-		const { result } = renderHook(() => useTradeMutation('GWALLET'), { wrapper });
+		const { Wrapper } = createWrapper();
+		const { result } = renderHook(() => useTradeMutation('GWALLET'), { wrapper: Wrapper });
 
 		result.current.mutate({
 			creatorId: 'creator-1',
@@ -61,8 +64,8 @@ describe('useTradeMutation cache invalidation log (#636)', () => {
 	it('does not emit the log in test environment', async () => {
 		const debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
 
-		const wrapper = createWrapper();
-		const { result } = renderHook(() => useTradeMutation('GWALLET'), { wrapper });
+		const { Wrapper } = createWrapper();
+		const { result } = renderHook(() => useTradeMutation('GWALLET'), { wrapper: Wrapper });
 
 		result.current.mutate({
 			creatorId: 'creator-2',
@@ -76,5 +79,31 @@ describe('useTradeMutation cache invalidation log (#636)', () => {
 		expect(debugSpy).not.toHaveBeenCalled();
 
 		debugSpy.mockRestore();
+	});
+
+	it('invalidates the marketplace list cache after a trade settles (#691)', async () => {
+		const { queryClient, Wrapper } = createWrapper();
+
+		queryClient.setQueryData(queryKeys.creators.infiniteList(undefined), {
+			pages: [{ items: [], page: 1, hasMore: false }],
+			pageParams: [1],
+		});
+
+		const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+		const { result } = renderHook(() => useTradeMutation('GWALLET'), { wrapper: Wrapper });
+
+		result.current.mutate({
+			creatorId: 'creator-3',
+			amount: 2,
+			priceStroops: 250_000,
+			price: 0.03,
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true), { timeout: 3000 });
+
+		expect(invalidateSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ queryKey: queryKeys.creators.all }),
+		);
 	});
 });

--- a/src/hooks/__tests__/useInfiniteCreatorMarketplace.test.ts
+++ b/src/hooks/__tests__/useInfiniteCreatorMarketplace.test.ts
@@ -8,6 +8,7 @@ import React from 'react';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { useInfiniteCreatorMarketplace } from '../useInfiniteCreatorMarketplace';
 import { courseService, type Course, type CoursesPage } from '@/services/course.service';
+import { queryKeys } from '@/lib/queryKeys';
 
 vi.mock('@/services/course.service', async () => {
 	const actual = await vi.importActual<typeof import('@/services/course.service')>(
@@ -126,5 +127,106 @@ describe('useInfiniteCreatorMarketplace', () => {
 		});
 
 		await waitFor(() => expect(mockGetCoursesPage).toHaveBeenCalledWith(1, params));
+	});
+
+	describe('stale-while-revalidate (#691)', () => {
+		it('serves cached data instantly (no first-page loading state) on remount within 60s', async () => {
+			mockGetCoursesPage.mockResolvedValue({
+				items: [makeCreator('a')],
+				page: 1,
+				hasMore: false,
+			});
+
+			const queryClient = new QueryClient({
+				defaultOptions: { queries: { retry: false } },
+			});
+			const wrapper = ({ children }: { children: React.ReactNode }) =>
+				React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+			const first = renderHook(() => useInfiniteCreatorMarketplace(), { wrapper });
+			await waitFor(() => expect(first.result.current.isLoadingFirstPage).toBe(false));
+			first.unmount();
+
+			mockGetCoursesPage.mockClear();
+
+			const second = renderHook(() => useInfiniteCreatorMarketplace(), { wrapper });
+
+			// Cached data must be available immediately -- never a spinner state
+			// -- because the previous fetch is still within the 60s staleTime.
+			expect(second.result.current.isLoadingFirstPage).toBe(false);
+			expect(second.result.current.creators).toHaveLength(1);
+			expect(mockGetCoursesPage).not.toHaveBeenCalled();
+		});
+
+		it('reports isRefreshing while silently refetching stale data in the background', async () => {
+			mockGetCoursesPage.mockResolvedValue({
+				items: [makeCreator('a')],
+				page: 1,
+				hasMore: false,
+			});
+
+			const queryClient = new QueryClient({
+				defaultOptions: { queries: { retry: false } },
+			});
+			const wrapper = ({ children }: { children: React.ReactNode }) =>
+				React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+			const { result } = renderHook(() => useInfiniteCreatorMarketplace(), { wrapper });
+			await waitFor(() => expect(result.current.isLoadingFirstPage).toBe(false));
+
+			expect(result.current.isRefreshing).toBe(false);
+
+			// Slow down the refetch so the transient "refreshing" window is
+			// actually observable instead of resolving synchronously.
+			let resolveRefetch!: (page: CoursesPage) => void;
+			mockGetCoursesPage.mockReturnValueOnce(
+				new Promise(resolve => {
+					resolveRefetch = resolve;
+				})
+			);
+
+			// Force the cached entry to be considered stale, then trigger a
+			// background refetch the way a remount-after-60s would.
+			queryClient.invalidateQueries({ queryKey: queryKeys.creators.infiniteList(undefined) });
+
+			await waitFor(() => expect(result.current.isRefreshing).toBe(true));
+			// Cached data must remain visible throughout -- no spinner regression.
+			expect(result.current.isLoadingFirstPage).toBe(false);
+			expect(result.current.creators).toHaveLength(1);
+
+			resolveRefetch({ items: [makeCreator('a')], page: 1, hasMore: false });
+			await waitFor(() => expect(result.current.isRefreshing).toBe(false));
+		});
+
+		it('does not set isRefreshing during the initial load or next-page fetch', async () => {
+			let resolveFirstPage!: (page: CoursesPage) => void;
+			mockGetCoursesPage.mockReturnValueOnce(
+				new Promise(resolve => {
+					resolveFirstPage = resolve;
+				})
+			);
+
+			const { result } = renderHook(() => useInfiniteCreatorMarketplace(), {
+				wrapper: createWrapper(),
+			});
+
+			expect(result.current.isRefreshing).toBe(false);
+			resolveFirstPage({ items: [makeCreator('a')], page: 1, hasMore: true });
+			await waitFor(() => expect(result.current.isLoadingFirstPage).toBe(false));
+			expect(result.current.isRefreshing).toBe(false);
+
+			let resolveNextPage!: (page: CoursesPage) => void;
+			mockGetCoursesPage.mockReturnValueOnce(
+				new Promise(resolve => {
+					resolveNextPage = resolve;
+				})
+			);
+
+			result.current.fetchNextPage();
+			await waitFor(() => expect(result.current.isFetchingNextPage).toBe(true));
+			expect(result.current.isRefreshing).toBe(false);
+
+			resolveNextPage({ items: [makeCreator('b')], page: 2, hasMore: false });
+		});
 	});
 });

--- a/src/hooks/__tests__/useNavigationTiming.test.ts
+++ b/src/hooks/__tests__/useNavigationTiming.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for useNavigationTiming — logs TTFB/DCL/load-complete via the
+ * Navigation Timing API after each mount of the marketplace and creator
+ * profile pages (#693).
+ */
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useNavigationTiming } from '../useNavigationTiming';
+
+function mockNavigationEntry(overrides: Partial<PerformanceNavigationTiming> = {}) {
+	const entry = {
+		requestStart: 10,
+		responseStart: 60,
+		startTime: 0,
+		domContentLoadedEventEnd: 200,
+		loadEventEnd: 350,
+		...overrides,
+	} as PerformanceNavigationTiming;
+
+	vi.spyOn(performance, 'getEntriesByType').mockReturnValue([entry]);
+	return entry;
+}
+
+describe('useNavigationTiming', () => {
+	let originalReadyState: string;
+
+	beforeEach(() => {
+		originalReadyState = document.readyState;
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllEnvs();
+		Object.defineProperty(document, 'readyState', {
+			value: originalReadyState,
+			configurable: true,
+		});
+	});
+
+	function setProd(value: boolean) {
+		vi.stubEnv('PROD', value);
+	}
+
+	function setReadyState(value: DocumentReadyState) {
+		Object.defineProperty(document, 'readyState', { value, configurable: true });
+	}
+
+	it('does not log when not in production mode', () => {
+		setProd(false);
+		setReadyState('complete');
+		mockNavigationEntry();
+		const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+		renderHook(() => useNavigationTiming('marketplace'));
+
+		expect(infoSpy).not.toHaveBeenCalled();
+	});
+
+	it('logs ttfb, dcl, load_complete, and page_name in production mode', () => {
+		setProd(true);
+		setReadyState('complete');
+		mockNavigationEntry({
+			requestStart: 10,
+			responseStart: 60,
+			startTime: 0,
+			domContentLoadedEventEnd: 200,
+			loadEventEnd: 350,
+		});
+		const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+		renderHook(() => useNavigationTiming('marketplace'));
+
+		expect(infoSpy).toHaveBeenCalledWith('[page-load-perf]', {
+			page_name: 'marketplace',
+			ttfb: 50,
+			dcl: 200,
+			load_complete: 350,
+		});
+	});
+
+	it('logs after the load event when the document has not finished loading yet', () => {
+		setProd(true);
+		setReadyState('loading');
+		mockNavigationEntry();
+		const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+		renderHook(() => useNavigationTiming('creator_profile'));
+
+		expect(infoSpy).not.toHaveBeenCalled();
+
+		window.dispatchEvent(new Event('load'));
+
+		expect(infoSpy).toHaveBeenCalledWith(
+			'[page-load-perf]',
+			expect.objectContaining({ page_name: 'creator_profile' })
+		);
+	});
+
+	it('logs only once per mount even if the hook re-renders', () => {
+		setProd(true);
+		setReadyState('complete');
+		mockNavigationEntry();
+		const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+		const { rerender } = renderHook(({ page }) => useNavigationTiming(page), {
+			initialProps: { page: 'marketplace' },
+		});
+
+		rerender({ page: 'marketplace' });
+		rerender({ page: 'marketplace' });
+
+		expect(infoSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('does nothing when no navigation timing entry is available', () => {
+		setProd(true);
+		setReadyState('complete');
+		vi.spyOn(performance, 'getEntriesByType').mockReturnValue([]);
+		const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+		renderHook(() => useNavigationTiming('marketplace'));
+
+		expect(infoSpy).not.toHaveBeenCalled();
+	});
+});

--- a/src/hooks/useInfiniteCreatorMarketplace.ts
+++ b/src/hooks/useInfiniteCreatorMarketplace.ts
@@ -5,6 +5,10 @@ import { queryKeys } from '@/lib/queryKeys';
 
 const FIRST_PAGE = 1;
 
+// #691 — cached pages are served instantly and treated as fresh for this
+// long; a background refetch only kicks in once data is older than this.
+const MARKETPLACE_STALE_TIME_MS = 60_000;
+
 /**
  * Cursor-based (page-number) infinite pagination over the creator key
  * marketplace listing, backed by React Query's useInfiniteQuery (#685).
@@ -13,6 +17,11 @@ const FIRST_PAGE = 1;
  * paged fetches: only the first page loads initially, later pages fetch on
  * demand via `fetchNextPage` (wire this to a useInfiniteScroll sentinel),
  * and fetching stops once the last page reports `hasMore: false`.
+ *
+ * #691 — `staleTime` enables stale-while-revalidate: a cached list renders
+ * immediately (no spinner) on remount within 60s, while React Query silently
+ * refetches in the background once it's stale. `isRefreshing` distinguishes
+ * that silent background refetch from the initial (spinner-worthy) load.
  */
 export function useInfiniteCreatorMarketplace(params?: Omit<GetCoursesParams, 'page'>) {
 	const query = useInfiniteQuery({
@@ -20,6 +29,7 @@ export function useInfiniteCreatorMarketplace(params?: Omit<GetCoursesParams, 'p
 		queryFn: ({ pageParam }) => courseService.getCoursesPage(pageParam, params),
 		initialPageParam: FIRST_PAGE,
 		getNextPageParam: lastPage => (lastPage.hasMore ? lastPage.page + 1 : undefined),
+		staleTime: MARKETPLACE_STALE_TIME_MS,
 	});
 
 	// De-duplicate creators across pages by id -- a creator that shifts
@@ -43,6 +53,10 @@ export function useInfiniteCreatorMarketplace(params?: Omit<GetCoursesParams, 'p
 		hasMore: query.hasNextPage,
 		isLoadingFirstPage: query.isLoading,
 		isFetchingNextPage: query.isFetchingNextPage,
+		// True only while a background revalidation is in flight after data
+		// has already been shown once — never true during the very first,
+		// spinner-worthy load (that's isLoadingFirstPage).
+		isRefreshing: query.isFetching && !query.isLoading && !query.isFetchingNextPage,
 		fetchNextPage: query.fetchNextPage,
 		error: query.error,
 	};

--- a/src/hooks/useNavigationTiming.ts
+++ b/src/hooks/useNavigationTiming.ts
@@ -1,56 +1,60 @@
 import { useEffect, useRef } from 'react';
-import { useLocation } from 'react-router';
 
-interface NavigationTiming {
-	route: string;
-	dom_content_loaded_ms: number;
-	load_event_ms: number;
-	time_to_first_byte_ms: number;
+export interface PageLoadTiming {
+	page_name: string;
+	ttfb: number;
+	dcl: number;
+	load_complete: number;
 }
 
-function readNavigationTiming(): {
-	timing: NavigationTiming;
-	startTime: number;
-} | null {
+function readNavigationTiming(pageName: string): PageLoadTiming | null {
 	const entries = performance.getEntriesByType('navigation');
 	if (!entries.length) return null;
 
 	const nav = entries[0] as PerformanceNavigationTiming;
 
 	return {
-		timing: {
-			route: window.location.pathname,
-			dom_content_loaded_ms: Math.round(
-				nav.domContentLoadedEventEnd - nav.startTime
-			),
-			load_event_ms: Math.round(nav.loadEventEnd - nav.startTime),
-			time_to_first_byte_ms: Math.round(
-				nav.responseStart - nav.requestStart
-			),
-		},
-		startTime: nav.startTime,
+		page_name: pageName,
+		ttfb: Math.round(nav.responseStart - nav.requestStart),
+		dcl: Math.round(nav.domContentLoadedEventEnd - nav.startTime),
+		load_complete: Math.round(nav.loadEventEnd - nav.startTime),
 	};
 }
 
-export function useNavigationTiming() {
-	const location = useLocation();
-	const loggedStartTime = useRef<number | null>(null);
+/**
+ * Logs page-load performance (TTFB / DOM Content Loaded / load complete) via
+ * the Navigation Timing API after the page becomes interactive (#693).
+ *
+ * - Production only (`import.meta.env.PROD`) — never fires in dev/test, so
+ *   it can't add noise or overhead to local development.
+ * - Debounced to exactly one log per mount via a ref guard, so re-renders
+ *   (state updates, prop changes) never produce duplicate logs.
+ * - Reads happen after `load` (or immediately if the page already finished
+ *   loading by the time this effect runs) and never block rendering — the
+ *   read + log is entirely async relative to the render path.
+ */
+export function useNavigationTiming(pageName: string) {
+	const hasLogged = useRef(false);
 
 	useEffect(() => {
-		function emit() {
-			const result = readNavigationTiming();
-			if (!result) return;
-			if (loggedStartTime.current === result.startTime) return;
+		if (!import.meta.env.PROD) return;
+		if (hasLogged.current) return;
 
-			loggedStartTime.current = result.startTime;
-			console.debug('[navigation-timing]', result.timing);
+		function emit() {
+			if (hasLogged.current) return;
+			const timing = readNavigationTiming(pageName);
+			if (!timing) return;
+
+			hasLogged.current = true;
+			console.info('[page-load-perf]', timing);
 		}
 
 		if (document.readyState === 'complete') {
 			emit();
-		} else {
-			window.addEventListener('load', emit, { once: true });
-			return () => window.removeEventListener('load', emit);
+			return;
 		}
-	}, [location]);
+
+		window.addEventListener('load', emit, { once: true });
+		return () => window.removeEventListener('load', emit);
+	}, [pageName]);
 }

--- a/src/hooks/useWallet.ts
+++ b/src/hooks/useWallet.ts
@@ -136,9 +136,18 @@ export function useTradeMutation(address: string) {
 			);
 		},
 		onSettled: (_data, _error, variables) => {
-			const invalidatedKeys = [queryKeys.wallet.holdings(address)];
+			// #691 — a completed buy/sell changes supply/price data backing the
+			// marketplace list, so its cache must not wait out the 60s
+			// staleTime; invalidate immediately regardless of the trade outcome.
+			const invalidatedKeys = [
+				queryKeys.wallet.holdings(address),
+				queryKeys.creators.all,
+			];
 			queryClient.invalidateQueries({
 				queryKey: queryKeys.wallet.holdings(address),
+			});
+			queryClient.invalidateQueries({
+				queryKey: queryKeys.creators.all,
 			});
 
 			if (process.env.NODE_ENV !== 'test') {

--- a/src/pages/CreatorDetailPage.tsx
+++ b/src/pages/CreatorDetailPage.tsx
@@ -7,10 +7,12 @@ import { CreatorProfileHeaderSkeleton } from '@/components/common/CreatorSkeleto
 import { bpsToPercent } from '@/utils/numberFormat.utils';
 import CreatorPageErrorBoundary from '@/components/common/CreatorPageErrorBoundary';
 import { ApiError } from '@/services/api.service';
+import { useNavigationTiming } from '@/hooks/useNavigationTiming';
 
 function CreatorDetailPageContent() {
 	const { id } = useParams<{ id: string }>();
 	const { data: creator, isLoading, error } = useCreatorDetail(id || '');
+	useNavigationTiming('creator_profile');
 
 	if (isLoading) {
 		return (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -3,8 +3,11 @@ import Footer from '../components/home/Footer';
 import Header from '../components/home/Header';
 import Hero from '../components/home/Hero';
 import TrendingCreators from '../components/home/TrendingCreators';
+import { useNavigationTiming } from '../hooks/useNavigationTiming';
 
 export default function HomePage() {
+	useNavigationTiming('marketplace');
+
 	return (
 		<>
 			<Header />


### PR DESCRIPTION
## Summary
Three independent, related improvements to the marketplace/creator-profile experience: a scoped error boundary around the bonding curve chart, stale-while-revalidate caching for the marketplace list, and Navigation Timing API perf logging on the two key pages.

closes #690
closes #691
closes #693

## Changes

- **#690 — Error boundary around the bonding curve chart**: `SectionErrorBoundary` gained two new optional, backward-compatible props (`title`, `description`) so its fallback copy can be overridden per-section (all existing callers — `LandingPage.tsx`'s creator list/`AppErrorBoundary` — are unaffected since neither prop is passed there). The bonding-curve sparkline block in `CreatorCard.tsx` is now wrapped in `<SectionErrorBoundary title="Chart unavailable — try refreshing" description="" ...>`, so a chart-render crash no longer takes down the whole card. Retry is manual only (clicking "Retry" resets the boundary) — there is no auto-retry loop. The caught error is logged via the boundary's existing `componentDidCatch` → `console.error`.

- **#691 — Stale-while-revalidate cache for the marketplace list**: `useInfiniteCreatorMarketplace` now sets `staleTime: 60_000` on its `useInfiniteQuery`, so a cached page renders instantly (no spinner) on remount within 60s while React Query silently refetches in the background once stale. The hook exposes a new `isRefreshing` flag — true only while a background refetch is in flight after data has already been shown once, never during the initial load or a next-page fetch — which `CreatorMarketplaceInfiniteList` uses to show a small "Refreshing…" `role="status"` indicator. `useTradeMutation`'s `onSettled` now also invalidates `queryKeys.creators.all` (in addition to the existing wallet-holdings invalidation), so a completed buy/sell doesn't have to wait out the 60s staleTime before the marketplace reflects the trade.

- **#693 — Page-load performance logging**: Reworked the existing (but incomplete) `useNavigationTiming` hook to accept a `pageName`, read `performance.getEntriesByType('navigation')[0]` after the page becomes interactive, and log `{ page_name, ttfb, dcl, load_complete }` via `console.info('[page-load-perf]', ...)`. Logging is gated to `import.meta.env.PROD` (never fires in dev/test), debounced via a ref guard to exactly one log per mount, and happens asynchronously after the `load` event so it never blocks rendering. The hook's call site moved from `App.tsx` (fired globally on every route with no production gate or exact field names) to `HomePage` (`page_name: 'marketplace'`) and `CreatorDetailPage` (`page_name: 'creator_profile'`) specifically, matching the issue's scope.

## Test plan
- `SectionErrorBoundary.test.tsx`: 9 tests (4 pre-existing + 5 new) covering custom title/description, description omission, manual-only retry, and the `componentDidCatch` log — all passing.
- `useInfiniteCreatorMarketplace.test.ts`: 7 tests (4 pre-existing + 3 new) covering instant cache-hit on remount, `isRefreshing` toggling correctly around a background refetch, and `isRefreshing` staying false during initial/next-page loads — all passing.
- `CreatorMarketplaceInfiniteList.test.tsx`: 9 tests (6 pre-existing + 3 new) covering the "Refreshing…" indicator's visibility and that cached creators keep rendering (no skeleton regression) during a background refresh — all passing.
- `tradeCacheInvalidation.test.ts`: 3 tests (2 pre-existing + 1 new) covering that `queryKeys.creators.all` is invalidated on trade settlement — all passing.
- `useNavigationTiming.test.ts` (new file): 5 tests covering the PROD gate, exact log shape, the `load`-event fallback path, single-log-per-mount debouncing, and the no-entry-available case — all passing.
- `npx tsc -b` (project build/typecheck) and `npx eslint` on all touched files are clean.
- Ran the full `vitest` suite: all failures present (`TransactionHistory.*`, `WalletActivityFeed.infiniteScroll.integration.test.tsx`) are pre-existing and unrelated — confirmed by reproducing the same `localStorage.clear is not a function` failure with these commits fully reverted (stash test). No regressions introduced by this PR.

---
`LandingPage.tsx` (which also renders creator cards/bonding-curve charts and already consumes `SectionErrorBoundary` elsewhere) isn't currently wired into `routes.tsx` and appears to be a separate, not-yet-routed page — #690's fix was applied at the `CreatorCard` component level instead, so it covers every place the chart is actually rendered today, including wherever `LandingPage` eventually gets wired up.