### PR TITLE
feat: add notification bell in nav bar with unread badge and dropdown…

### DIFF
--- a/src/components/common/NotificationBell.tsx
+++ b/src/components/common/NotificationBell.tsx
@@ -1,0 +1,160 @@
+import { Bell } from 'lucide-react';
+import { useNavigate } from 'react-router';
+import { cn } from '@/lib/utils';
+import { useNotifications } from '@/hooks/useNotifications';
+import { formatRelativeTime } from '@/utils/time.utils';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+interface NotificationBellProps {
+	/** The authenticated user's id used as the cache key. */
+	userId: string;
+	className?: string;
+}
+
+/**
+ * Notification bell for the nav bar (issue #720).
+ *
+ * Shows an unread-count badge when count > 0, opens a dropdown of the five
+ * most recent notifications, marks items read on click, and provides a
+ * "View all" link to /notifications.
+ */
+export function NotificationBell({ userId, className = '' }: NotificationBellProps) {
+	const navigate = useNavigate();
+	const { recent, unreadCount, isLoading, markAsRead } = useNotifications(userId);
+
+	const handleNotificationClick = (notificationId: string, href: string) => {
+		markAsRead(notificationId);
+		void navigate(href);
+	};
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<button
+					type="button"
+					aria-label={
+						unreadCount > 0
+							? `Notifications — ${unreadCount} unread`
+							: 'Notifications'
+					}
+					className={cn(
+						'relative inline-flex items-center justify-center rounded-full p-2 transition-colors',
+						'text-white/70 hover:bg-white/10 hover:text-white',
+						className
+					)}
+				>
+					<Bell className="size-5" aria-hidden="true" />
+					{unreadCount > 0 && (
+						<span
+							data-testid="notification-unread-badge"
+							aria-hidden="true"
+							className="absolute right-1 top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 font-mono text-[10px] font-bold leading-none text-white"
+						>
+							{unreadCount > 99 ? '99+' : unreadCount}
+						</span>
+					)}
+				</button>
+			</DropdownMenuTrigger>
+
+			<DropdownMenuContent
+				align="end"
+				className="w-80"
+				data-testid="notification-dropdown"
+			>
+				<DropdownMenuLabel className="flex items-center justify-between">
+					<span>Notifications</span>
+					{unreadCount > 0 && (
+						<span className="ml-2 rounded-full bg-red-500/15 px-2 py-0.5 text-xs font-semibold text-red-500">
+							{unreadCount} unread
+						</span>
+					)}
+				</DropdownMenuLabel>
+
+				<DropdownMenuSeparator />
+
+				{isLoading && (
+					<div
+						data-testid="notification-loading"
+						className="space-y-2 p-2"
+					>
+						{Array.from({ length: 3 }).map((_, i) => (
+							<div
+								key={i}
+								className="h-12 w-full animate-pulse rounded-md bg-muted"
+							/>
+						))}
+					</div>
+				)}
+
+				{!isLoading && recent.length === 0 && (
+					<p
+						data-testid="notification-empty-state"
+						className="px-3 py-6 text-center text-sm text-muted-foreground"
+					>
+						No notifications yet
+					</p>
+				)}
+
+				{!isLoading &&
+					recent.map(notification => (
+						<DropdownMenuItem
+							key={notification.id}
+							data-testid={`notification-item-${notification.id}`}
+							className={cn(
+								'flex cursor-pointer flex-col items-start gap-1 px-3 py-2.5',
+								!notification.read && 'bg-accent/40'
+							)}
+							onSelect={() =>
+								handleNotificationClick(
+									notification.id,
+									notification.href
+								)
+							}
+						>
+							<div className="flex w-full items-start gap-2">
+								{/* Unread indicator dot */}
+								{!notification.read && (
+									<span
+										aria-label="Unread"
+										className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-blue-500"
+									/>
+								)}
+								<span
+									className={cn(
+										'flex-1 text-sm leading-snug',
+										notification.read
+											? 'text-muted-foreground'
+											: 'font-medium text-foreground'
+									)}
+								>
+									{notification.message}
+								</span>
+							</div>
+							<span className="pl-4 text-xs text-muted-foreground">
+								{formatRelativeTime(notification.createdAt)}
+							</span>
+						</DropdownMenuItem>
+					))}
+
+				<DropdownMenuSeparator />
+
+				<DropdownMenuItem
+					data-testid="notification-view-all"
+					className="justify-center text-sm font-medium text-primary hover:text-primary"
+					onSelect={() => void navigate('/notifications')}
+				>
+					View all
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
+export default NotificationBell;

--- a/src/components/common/__tests__/NotificationBell.test.tsx
+++ b/src/components/common/__tests__/NotificationBell.test.tsx
@@ -278,7 +278,6 @@ describe('NotificationBell', () => {
 	// ── Badge decrement ──────────────────────────────────────────────────────
 
 	it('badge count decrements after a notification is marked read', async () => {
-		const user = userEvent.setup();
 		const markAsRead = vi.fn();
 
 		// Start with count = 2

--- a/src/components/common/__tests__/NotificationBell.test.tsx
+++ b/src/components/common/__tests__/NotificationBell.test.tsx
@@ -1,0 +1,326 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import NotificationBell from '@/components/common/NotificationBell';
+import { useNotifications } from '@/hooks/useNotifications';
+import type { Notification } from '@/services/notification.service';
+
+vi.mock('@/hooks/useNotifications');
+vi.mock('react-router', async () => {
+	const actual = await vi.importActual<typeof import('react-router')>('react-router');
+	return { ...actual, useNavigate: vi.fn(() => vi.fn()) };
+});
+
+const mockUseNotifications = vi.mocked(useNotifications);
+
+function makeNotification(
+	id: string,
+	overrides: Partial<Notification> = {}
+): Notification {
+	return {
+		id,
+		type: 'new_follower',
+		message: `Notification message ${id}`,
+		createdAt: new Date(Date.now() - 60_000).toISOString(),
+		read: false,
+		href: `/creator/${id}`,
+		...overrides,
+	};
+}
+
+function renderBell(userId = 'user_abc') {
+	return render(
+		<MemoryRouter>
+			<NotificationBell userId={userId} />
+		</MemoryRouter>
+	);
+}
+
+describe('NotificationBell', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	// ── Badge visibility ─────────────────────────────────────────────────────
+
+	it('does not show the unread badge when unreadCount is 0', () => {
+		mockUseNotifications.mockReturnValue({
+			recent: [],
+			unreadCount: 0,
+			isLoading: false,
+			isError: false,
+			markAsRead: vi.fn(),
+		});
+
+		renderBell();
+
+		expect(
+			screen.queryByTestId('notification-unread-badge')
+		).not.toBeInTheDocument();
+	});
+
+	it('shows the unread badge with the correct count when unreadCount > 0', () => {
+		mockUseNotifications.mockReturnValue({
+			recent: [makeNotification('n1')],
+			unreadCount: 3,
+			isLoading: false,
+			isError: false,
+			markAsRead: vi.fn(),
+		});
+
+		renderBell();
+
+		const badge = screen.getByTestId('notification-unread-badge');
+		expect(badge).toBeInTheDocument();
+		expect(badge).toHaveTextContent('3');
+	});
+
+	it('caps the badge display at 99+ when unreadCount > 99', () => {
+		mockUseNotifications.mockReturnValue({
+			recent: [],
+			unreadCount: 150,
+			isLoading: false,
+			isError: false,
+			markAsRead: vi.fn(),
+		});
+
+		renderBell();
+
+		expect(screen.getByTestId('notification-unread-badge')).toHaveTextContent(
+			'99+'
+		);
+	});
+
+	// ── Accessible label ─────────────────────────────────────────────────────
+
+	it('gives the bell button an accessible label mentioning unread count', () => {
+		mockUseNotifications.mockReturnValue({
+			recent: [],
+			unreadCount: 2,
+			isLoading: false,
+			isError: false,
+			markAsRead: vi.fn(),
+		});
+
+		renderBell();
+
+		expect(
+			screen.getByRole('button', { name: /notifications — 2 unread/i })
+		).toBeInTheDocument();
+	});
+
+	it('uses a generic label when unreadCount is 0', () => {
+		mockUseNotifications.mockReturnValue({
+			recent: [],
+			unreadCount: 0,
+			isLoading: false,
+			isError: false,
+			markAsRead: vi.fn(),
+		});
+
+		renderBell();
+
+		expect(
+			screen.getByRole('button', { name: /^notifications$/i })
+		).toBeInTheDocument();
+	});
+
+	// ── Dropdown content ─────────────────────────────────────────────────────
+
+	it('opens the dropdown when the bell is clicked', async () => {
+		const user = userEvent.setup();
+		mockUseNotifications.mockReturnValue({
+			recent: [],
+			unreadCount: 0,
+			isLoading: false,
+			isError: false,
+			markAsRead: vi.fn(),
+		});
+
+		renderBell();
+
+		await user.click(screen.getByRole('button', { name: /notifications/i }));
+
+		expect(
+			screen.getByTestId('notification-dropdown')
+		).toBeInTheDocument();
+	});
+
+	it('shows the empty state when there are no notifications', async () => {
+		const user = userEvent.setup();
+		mockUseNotifications.mockReturnValue({
+			recent: [],
+			unreadCount: 0,
+			isLoading: false,
+			isError: false,
+			markAsRead: vi.fn(),
+		});
+
+		renderBell();
+		await user.click(screen.getByRole('button', { name: /notifications/i }));
+
+		expect(
+			screen.getByTestId('notification-empty-state')
+		).toBeInTheDocument();
+		expect(
+			screen.getByText('No notifications yet')
+		).toBeInTheDocument();
+	});
+
+	it('shows skeleton rows while loading', async () => {
+		const user = userEvent.setup();
+		mockUseNotifications.mockReturnValue({
+			recent: [],
+			unreadCount: 0,
+			isLoading: true,
+			isError: false,
+			markAsRead: vi.fn(),
+		});
+
+		renderBell();
+		await user.click(screen.getByRole('button', { name: /notifications/i }));
+
+		expect(screen.getByTestId('notification-loading')).toBeInTheDocument();
+		expect(
+			screen.queryByTestId('notification-empty-state')
+		).not.toBeInTheDocument();
+	});
+
+	it('renders up to five notification items in the dropdown', async () => {
+		const user = userEvent.setup();
+		const recent = [
+			makeNotification('n1'),
+			makeNotification('n2'),
+			makeNotification('n3'),
+			makeNotification('n4'),
+			makeNotification('n5'),
+		];
+		mockUseNotifications.mockReturnValue({
+			recent,
+			unreadCount: 5,
+			isLoading: false,
+			isError: false,
+			markAsRead: vi.fn(),
+		});
+
+		renderBell();
+		await user.click(screen.getByRole('button', { name: /notifications/i }));
+
+		for (const n of recent) {
+			expect(
+				screen.getByTestId(`notification-item-${n.id}`)
+			).toBeInTheDocument();
+		}
+	});
+
+	it('shows the notification message text for each item', async () => {
+		const user = userEvent.setup();
+		const recent = [makeNotification('n1', { message: 'Alice followed you' })];
+		mockUseNotifications.mockReturnValue({
+			recent,
+			unreadCount: 1,
+			isLoading: false,
+			isError: false,
+			markAsRead: vi.fn(),
+		});
+
+		renderBell();
+		await user.click(screen.getByRole('button', { name: /notifications/i }));
+
+		expect(screen.getByText('Alice followed you')).toBeInTheDocument();
+	});
+
+	// ── Marking read ─────────────────────────────────────────────────────────
+
+	it('calls markAsRead with the notification id when an item is clicked', async () => {
+		const user = userEvent.setup();
+		const markAsRead = vi.fn();
+		const recent = [makeNotification('n1')];
+		mockUseNotifications.mockReturnValue({
+			recent,
+			unreadCount: 1,
+			isLoading: false,
+			isError: false,
+			markAsRead,
+		});
+
+		renderBell();
+		await user.click(screen.getByRole('button', { name: /notifications/i }));
+		await user.click(screen.getByTestId('notification-item-n1'));
+
+		expect(markAsRead).toHaveBeenCalledWith('n1');
+	});
+
+	// ── View all link ────────────────────────────────────────────────────────
+
+	it('renders a "View all" link in the dropdown', async () => {
+		const user = userEvent.setup();
+		mockUseNotifications.mockReturnValue({
+			recent: [],
+			unreadCount: 0,
+			isLoading: false,
+			isError: false,
+			markAsRead: vi.fn(),
+		});
+
+		renderBell();
+		await user.click(screen.getByRole('button', { name: /notifications/i }));
+
+		expect(
+			screen.getByTestId('notification-view-all')
+		).toBeInTheDocument();
+		expect(
+			screen.getByTestId('notification-view-all')
+		).toHaveTextContent('View all');
+	});
+
+	// ── Badge decrement ──────────────────────────────────────────────────────
+
+	it('badge count decrements after a notification is marked read', async () => {
+		const user = userEvent.setup();
+		const markAsRead = vi.fn();
+
+		// Start with count = 2
+		mockUseNotifications.mockReturnValue({
+			recent: [
+				makeNotification('n1', { read: false }),
+				makeNotification('n2', { read: false }),
+			],
+			unreadCount: 2,
+			isLoading: false,
+			isError: false,
+			markAsRead,
+		});
+
+		const { rerender } = renderBell();
+
+		expect(screen.getByTestId('notification-unread-badge')).toHaveTextContent(
+			'2'
+		);
+
+		// Simulate the hook returning updated state after markAsRead is called
+		mockUseNotifications.mockReturnValue({
+			recent: [
+				makeNotification('n1', { read: true }),
+				makeNotification('n2', { read: false }),
+			],
+			unreadCount: 1,
+			isLoading: false,
+			isError: false,
+			markAsRead,
+		});
+
+		rerender(
+			<MemoryRouter>
+				<NotificationBell userId="user_abc" />
+			</MemoryRouter>
+		);
+
+		await waitFor(() => {
+			expect(
+				screen.getByTestId('notification-unread-badge')
+			).toHaveTextContent('1');
+		});
+	});
+});

--- a/src/components/home/Header.tsx
+++ b/src/components/home/Header.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import WalletStatusChip from '@/components/common/WalletStatusChip';
+import NotificationBell from '@/components/common/NotificationBell';
+import { useProfileStore } from '@/hooks/useProfileStore';
 import { Link } from 'react-router';
 
 const navLinks = [
@@ -10,6 +12,7 @@ const navLinks = [
 
 export default function Header() {
 	const [scrolled, setScrolled] = useState(false);
+	const profile = useProfileStore(state => state.profile);
 
 	useEffect(() => {
 		const onScroll = () => {
@@ -66,10 +69,21 @@ export default function Header() {
 					)}
 				</nav>
 
-				{/* CTA — #686: a persistent wallet status chip replaces the bare
-				    Connect link. WalletStatusChip renders the same link itself when
-				    no wallet is connected, so the slot is never empty. */}
-				<WalletStatusChip />
+				{/* Right-side actions: notification bell (#720) + wallet status chip (#686).
+				    NotificationBell is only rendered when a user profile is available. */}
+				<div className="flex items-center gap-2">
+					{profile && (
+						<NotificationBell
+							userId={profile.id}
+							className={
+								scrolled
+									? 'text-gray-600 hover:bg-black/5 hover:text-gray-900'
+									: ''
+							}
+						/>
+					)}
+					<WalletStatusChip />
+				</div>
 			</div>
 		</header>
 	);

--- a/src/hooks/__tests__/useNotifications.test.ts
+++ b/src/hooks/__tests__/useNotifications.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useNotifications } from '@/hooks/useNotifications';
+import type { NotificationsResponse } from '@/services/notification.service';
+
+const USER_ID = 'user_abc123';
+
+function makeResponse(
+	overrides: Partial<NotificationsResponse> = {}
+): NotificationsResponse {
+	return {
+		notifications: [],
+		unreadCount: 0,
+		...overrides,
+	};
+}
+
+function makeWrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return ({ children }: { children: React.ReactNode }) =>
+		React.createElement(
+			QueryClientProvider,
+			{ client: queryClient },
+			children
+		);
+}
+
+describe('useNotifications', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('returns isLoading=true before the query resolves', () => {
+		const fetchFn = vi.fn(() => new Promise<NotificationsResponse>(() => {}));
+		const { result } = renderHook(
+			() => useNotifications(USER_ID, fetchFn),
+			{ wrapper: makeWrapper() }
+		);
+		expect(result.current.isLoading).toBe(true);
+	});
+
+	it('returns empty recent and zero unreadCount while loading', () => {
+		const fetchFn = vi.fn(() => new Promise<NotificationsResponse>(() => {}));
+		const { result } = renderHook(
+			() => useNotifications(USER_ID, fetchFn),
+			{ wrapper: makeWrapper() }
+		);
+		expect(result.current.recent).toEqual([]);
+		expect(result.current.unreadCount).toBe(0);
+	});
+
+	it('returns resolved notifications and unreadCount', async () => {
+		const notifications = [
+			{
+				id: 'n1',
+				type: 'new_follower' as const,
+				message: 'Alice started following you',
+				createdAt: new Date().toISOString(),
+				read: false,
+				href: '/creator/alice',
+			},
+		];
+		const fetchFn = vi.fn().mockResolvedValue(
+			makeResponse({ notifications, unreadCount: 1 })
+		);
+
+		const { result } = renderHook(
+			() => useNotifications(USER_ID, fetchFn),
+			{ wrapper: makeWrapper() }
+		);
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+		expect(result.current.recent).toHaveLength(1);
+		expect(result.current.recent[0].id).toBe('n1');
+		expect(result.current.unreadCount).toBe(1);
+	});
+
+	it('caps recent at five notifications even when the API returns more', async () => {
+		const notifications = Array.from({ length: 8 }, (_, i) => ({
+			id: `n${i}`,
+			type: 'new_follower' as const,
+			message: `Notification ${i}`,
+			createdAt: new Date().toISOString(),
+			read: false,
+			href: `/creator/${i}`,
+		}));
+		const fetchFn = vi.fn().mockResolvedValue(
+			makeResponse({ notifications, unreadCount: 8 })
+		);
+
+		const { result } = renderHook(
+			() => useNotifications(USER_ID, fetchFn),
+			{ wrapper: makeWrapper() }
+		);
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+		expect(result.current.recent).toHaveLength(5);
+	});
+
+	it('does not fetch when userId is empty', () => {
+		const fetchFn = vi.fn();
+		renderHook(() => useNotifications('', fetchFn), {
+			wrapper: makeWrapper(),
+		});
+		expect(fetchFn).not.toHaveBeenCalled();
+	});
+
+	it('applies an optimistic read update when markAsRead is called', async () => {
+		const notifications = [
+			{
+				id: 'n1',
+				type: 'new_follower' as const,
+				message: 'Alice started following you',
+				createdAt: new Date().toISOString(),
+				read: false,
+				href: '/creator/alice',
+			},
+			{
+				id: 'n2',
+				type: 'key_purchase' as const,
+				message: 'Bob bought your key',
+				createdAt: new Date().toISOString(),
+				read: false,
+				href: '/creator/bob',
+			},
+		];
+
+		// markAsRead hits the real notificationService — stub the module-level
+		// singleton so we can make it resolve without a real server.
+		vi.mock('@/services/notification.service', () => ({
+			notificationService: {
+				getNotifications: vi.fn(),
+				markAsRead: vi.fn().mockResolvedValue(undefined),
+			},
+			NotificationService: vi.fn(),
+		}));
+
+		const fetchFn = vi.fn().mockResolvedValue(
+			makeResponse({ notifications, unreadCount: 2 })
+		);
+
+		const { result } = renderHook(
+			() => useNotifications(USER_ID, fetchFn),
+			{ wrapper: makeWrapper() }
+		);
+
+		await waitFor(() => expect(result.current.isLoading).toBe(false));
+		expect(result.current.unreadCount).toBe(2);
+
+		act(() => {
+			result.current.markAsRead('n1');
+		});
+
+		// After the optimistic update the count should drop by 1.
+		await waitFor(() => expect(result.current.unreadCount).toBe(1));
+
+		// The mutated notification should now appear as read.
+		const n1 = result.current.recent.find(n => n.id === 'n1');
+		expect(n1?.read).toBe(true);
+
+		// The other notification remains unread.
+		const n2 = result.current.recent.find(n => n.id === 'n2');
+		expect(n2?.read).toBe(false);
+	});
+});

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,0 +1,91 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/lib/queryKeys';
+import {
+	notificationService,
+	type Notification,
+	type NotificationsResponse,
+} from '@/services/notification.service';
+
+const MAX_DROPDOWN_NOTIFICATIONS = 5;
+
+export interface UseNotificationsResult {
+	/** Up to five most recent notifications for the dropdown. */
+	recent: Notification[];
+	/** Total number of unread notifications. */
+	unreadCount: number;
+	isLoading: boolean;
+	isError: boolean;
+	/** Mark a single notification as read by its id. */
+	markAsRead: (notificationId: string) => void;
+}
+
+/**
+ * Fetches the current user's notifications and exposes a helper to mark
+ * individual items as read with an optimistic update.
+ *
+ * The queryFn is injected so tests can supply a stub without module-level
+ * patching (matches the pattern used in `useCreatorActivityFeed`).
+ */
+export function useNotifications(
+	userId: string,
+	fetchNotifications: (
+		id: string
+	) => Promise<NotificationsResponse> = id =>
+		notificationService.getNotifications(id)
+): UseNotificationsResult {
+	const queryClient = useQueryClient();
+	const queryKey = queryKeys.notifications.list(userId);
+
+	const { data, isLoading, isError } = useQuery({
+		queryKey,
+		queryFn: () => fetchNotifications(userId),
+		enabled: !!userId,
+	});
+
+	const { mutate: markAsRead } = useMutation({
+		mutationFn: (notificationId: string) =>
+			notificationService.markAsRead(notificationId),
+		// Optimistic update: flip the `read` flag and decrement the count
+		// so the badge responds instantly without waiting for the server.
+		onMutate: async (notificationId: string) => {
+			await queryClient.cancelQueries({ queryKey });
+
+			const previous =
+				queryClient.getQueryData<NotificationsResponse>(queryKey);
+
+			if (previous) {
+				queryClient.setQueryData<NotificationsResponse>(queryKey, {
+					notifications: previous.notifications.map(n =>
+						n.id === notificationId ? { ...n, read: true } : n
+					),
+					unreadCount: Math.max(0, previous.unreadCount - 1),
+				});
+			}
+
+			return { previous };
+		},
+		onError: (_err, _id, context) => {
+			// Roll back the optimistic update on failure.
+			if (context?.previous) {
+				queryClient.setQueryData<NotificationsResponse>(
+					queryKey,
+					context.previous
+				);
+			}
+		},
+		onSettled: () => {
+			void queryClient.invalidateQueries({ queryKey });
+		},
+	});
+
+	const allNotifications = data?.notifications ?? [];
+	const recent = allNotifications.slice(0, MAX_DROPDOWN_NOTIFICATIONS);
+
+	return {
+		recent,
+		unreadCount: data?.unreadCount ?? 0,
+		isLoading,
+		isError,
+		markAsRead,
+	};
+}

--- a/src/lib/queryKeys.ts
+++ b/src/lib/queryKeys.ts
@@ -30,4 +30,8 @@ export const queryKeys = {
 		holdings: (address: string) => ['wallet', address, 'holdings'] as const,
 		activity: (address: string) => ['wallet', address, 'activity'] as const,
 	},
+	notifications: {
+		all: () => ['notifications'] as const,
+		list: (userId: string) => ['notifications', userId, 'list'] as const,
+	},
 } as const;

--- a/src/pages/NotificationsPage.tsx
+++ b/src/pages/NotificationsPage.tsx
@@ -1,0 +1,125 @@
+import { Bell } from 'lucide-react';
+import { useNavigate } from 'react-router';
+import { cn } from '@/lib/utils';
+import { useNotifications } from '@/hooks/useNotifications';
+import { useProfileStore } from '@/hooks/useProfileStore';
+import { formatRelativeTime } from '@/utils/time.utils';
+import { useNavigationTiming } from '@/hooks/useNavigationTiming';
+
+export default function NotificationsPage() {
+	useNavigationTiming('notifications');
+
+	const navigate = useNavigate();
+	const profile = useProfileStore(state => state.profile);
+	const userId = profile?.id ?? '';
+
+	const { recent, unreadCount, isLoading, markAsRead } =
+		useNotifications(userId);
+
+	const handleNotificationClick = (
+		notificationId: string,
+		href: string
+	) => {
+		markAsRead(notificationId);
+		void navigate(href);
+	};
+
+	return (
+		<main className="mx-auto max-w-2xl px-6 py-16">
+			<div className="mb-8 flex items-center gap-3">
+				<Bell className="size-6 text-foreground" aria-hidden="true" />
+				<h1 className="font-jakarta text-2xl font-semibold">
+					Notifications
+				</h1>
+				{unreadCount > 0 && (
+					<span className="rounded-full bg-red-500/15 px-2.5 py-0.5 text-sm font-semibold text-red-500">
+						{unreadCount} unread
+					</span>
+				)}
+			</div>
+
+			{isLoading && (
+				<div
+					data-testid="notifications-page-loading"
+					className="space-y-3"
+				>
+					{Array.from({ length: 5 }).map((_, i) => (
+						<div
+							key={i}
+							className="h-16 w-full animate-pulse rounded-xl bg-muted"
+						/>
+					))}
+				</div>
+			)}
+
+			{!isLoading && recent.length === 0 && (
+				<div
+					data-testid="notifications-page-empty"
+					className="flex flex-col items-center gap-3 rounded-2xl border border-border py-16 text-center"
+				>
+					<div className="flex size-12 items-center justify-center rounded-full border border-border bg-muted text-muted-foreground">
+						<Bell className="size-6" aria-hidden="true" />
+					</div>
+					<p className="text-sm text-muted-foreground">
+						No notifications yet
+					</p>
+				</div>
+			)}
+
+			{!isLoading && recent.length > 0 && (
+				<ul
+					data-testid="notifications-page-list"
+					className="divide-y divide-border rounded-xl border border-border"
+				>
+					{recent.map(notification => (
+						<li key={notification.id}>
+							<button
+								type="button"
+								data-testid={`notifications-page-item-${notification.id}`}
+								className={cn(
+									'flex w-full cursor-pointer items-start gap-3 px-4 py-4 text-left transition-colors hover:bg-accent/40',
+									!notification.read && 'bg-accent/20'
+								)}
+								onClick={() =>
+									handleNotificationClick(
+										notification.id,
+										notification.href
+									)
+								}
+							>
+								{!notification.read && (
+									<span
+										aria-label="Unread"
+										className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-blue-500"
+									/>
+								)}
+								<div
+									className={cn(
+										'flex-1',
+										notification.read && 'pl-4'
+									)}
+								>
+									<p
+										className={cn(
+											'text-sm',
+											notification.read
+												? 'text-muted-foreground'
+												: 'font-medium text-foreground'
+										)}
+									>
+										{notification.message}
+									</p>
+									<p className="mt-1 text-xs text-muted-foreground">
+										{formatRelativeTime(
+											notification.createdAt
+										)}
+									</p>
+								</div>
+							</button>
+						</li>
+					))}
+				</ul>
+			)}
+		</main>
+	);
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,6 +1,7 @@
 import HomePage from './pages/HomePage';
 import NotFoundPage from './pages/NotFoundPage';
 import CreatorDetailPage from './pages/CreatorDetailPage';
+import NotificationsPage from './pages/NotificationsPage';
 
 export const routes = [
 	{
@@ -18,6 +19,10 @@ export const routes = [
 	{
 		path: '/creators/:id',
 		element: <CreatorDetailPage />,
+	},
+	{
+		path: '/notifications',
+		element: <NotificationsPage />,
 	},
 	{
 		path: '*',

--- a/src/services/notification.service.ts
+++ b/src/services/notification.service.ts
@@ -1,0 +1,48 @@
+// src/services/notification.service.ts
+import { BaseApiService, type APIResponse } from './api.service';
+
+/** The kind of event that generated a notification. */
+export type NotificationType = 'new_follower' | 'key_purchase' | 'price_milestone';
+
+/** A single notification entry returned from the API. */
+export interface Notification {
+	id: string;
+	type: NotificationType;
+	message: string;
+	/** ISO 8601 timestamp when the notification was created. */
+	createdAt: string;
+	read: boolean;
+	/** Client-side path to navigate to when this notification is clicked. */
+	href: string;
+}
+
+/** Shape of the API response for a notifications list request. */
+export interface NotificationsResponse {
+	notifications: Notification[];
+	unreadCount: number;
+}
+
+class NotificationService extends BaseApiService {
+	/** Fetch the current user's notifications — GET /notifications */
+	async getNotifications(userId: string): Promise<NotificationsResponse> {
+		try {
+			const response = await this.api.get<
+				APIResponse<NotificationsResponse>
+			>(`/notifications`, { params: { userId } });
+			return response.data.data;
+		} catch (error) {
+			throw this.handleError(error);
+		}
+	}
+
+	/** Mark a single notification as read — PATCH /notifications/:id/read */
+	async markAsRead(notificationId: string): Promise<void> {
+		try {
+			await this.api.patch(`/notifications/${notificationId}/read`);
+		} catch (error) {
+			throw this.handleError(error);
+		}
+	}
+}
+
+export const notificationService = new NotificationService();


### PR DESCRIPTION
Closes #720

- Add NotificationBell component (src/components/common/NotificationBell.tsx)
  - Bell icon in the nav bar using lucide-react Bell icon
  - Unread count badge (red, capped at 99+) visible only when count > 0
  - Radix DropdownMenu shows up to 5 most recent notifications
  - Each item shows message, relative time (via formatRelativeTime), and an unread indicator dot
  - Clicking an item calls markAsRead() then navigates to notification.href
  - View all link at the bottom navigates to /notifications
  - Accessible aria-label includes unread count when present
  - Loading skeleton rows while query is in flight
  - Empty state when no notifications exist

- Add notification.service.ts (src/services/notification.service.ts)
  - Extends BaseApiService following existing service pattern
  - getNotifications(userId) - GET /notifications
  - markAsRead(notificationId) - PATCH /notifications/:id/read
  - Notification, NotificationType, NotificationsResponse types exported

- Add useNotifications hook (src/hooks/useNotifications.ts)
  - Wraps useQuery for data fetching (queryFn injected for testability)
  - Wraps useMutation for markAsRead with optimistic update: flips read flag and decrements unreadCount immediately, rolls back on error, invalidates on settled
  - Caps recent array at 5 items for dropdown display
  - Disabled when userId is empty

- Add notifications query key family (src/lib/queryKeys.ts)
  - queryKeys.notifications.all()
  - queryKeys.notifications.list(userId)

- Update Header (src/components/home/Header.tsx)
  - Import NotificationBell and useProfileStore
  - Render <NotificationBell userId={profile.id} /> when profile is set, placed left of WalletStatusChip in a flex gap-2 wrapper

- Add /notifications route (src/routes.tsx + src/pages/NotificationsPage.tsx)
  - Full-page notifications list matching View all destination
  - Uses the same useNotifications hook and formatRelativeTime

- Add tests
  - src/hooks/__tests__/useNotifications.test.ts: loading state, empty, data resolved, 5-item cap, disabled when no userId, optimistic update
  - src/components/common/__tests__/NotificationBell.test.tsx: badge visibility, 99+ cap, accessible labels, dropdown open, empty state, skeleton, 5 items rendered, message text, markAsRead called on click, View all link, badge decrement after read

## Summary

-

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm build`

## Checklist

- [ ] Linked issue or backlog item
- [ ] Scope is limited to the stated change
- [ ] Updated docs if behavior or setup changed
- [ ] Added screenshots for UI changes when relevant
